### PR TITLE
Add CRUD API endpoints for Role model

### DIFF
--- a/authentication/serializers.py
+++ b/authentication/serializers.py
@@ -34,3 +34,9 @@ class CustomUserDetailsSerializer(UserDetailsSerializer):
     class Meta(UserDetailsSerializer.Meta):
         fields = UserDetailsSerializer.Meta.fields + \
             ('phone', 'role', 'is_staff', 'first_name', 'last_name',)
+
+
+class RoleSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Role
+        fields = ['id', 'name', 'description']

--- a/authentication/tests.py
+++ b/authentication/tests.py
@@ -13,7 +13,7 @@ class RoleAPITests(APITestCase):
         self.role = Role.objects.create(name="Admin", description="Administrator role")
         self.user = User.objects.create_user(username="testuser", password="testpass", role=self.role)
         self.token = Token.objects.create(user=self.user)
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.key)
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.token.key}')
 
     def test_role_list_get(self):
         url = reverse('role-list')

--- a/authentication/tests.py
+++ b/authentication/tests.py
@@ -55,6 +55,12 @@ class RoleAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertFalse(Role.objects.filter(id=self.role.id).exists())
 
+    def test_role_detail_delete_nonexistent(self):
+        non_existent_id = self.role.id + 9999
+        url = reverse('role-detail', args=[non_existent_id])
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
 
 class RegistrationTestCase(APITestCase):
     def setUp(self):

--- a/authentication/tests.py
+++ b/authentication/tests.py
@@ -28,6 +28,14 @@ class RoleAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(response.data['name'], "Editor")
 
+    def test_role_list_post_invalid_data(self):
+        url = reverse('role-list')
+        # Missing required 'name' field
+        data = {"description": "Missing name"}
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('name', response.data)
+
     def test_role_detail_get(self):
         url = reverse('role-detail', args=[self.role.id])
         response = self.client.get(url)

--- a/authentication/urls.py
+++ b/authentication/urls.py
@@ -10,6 +10,7 @@ from authentication.views import email_confirm_redirect, password_reset_confirm_
 from dj_rest_auth.registration.views import RegisterView
 from dj_rest_auth.views import LoginView, LogoutView, UserDetailsView
 from django.urls import path
+from .views import role_list, role_detail
 
 
 urlpatterns = [
@@ -30,4 +31,8 @@ urlpatterns = [
         name="password_reset_confirm",
     ),
     path("password/reset/confirm/", PasswordResetConfirmView.as_view(), name="password_reset_confirm"),
+
+    path('roles/', role_list, name='role-list'),
+	path('roles/<int:pk>/', role_detail, name='role-detail'),
+
 ]

--- a/authentication/views.py
+++ b/authentication/views.py
@@ -1,5 +1,13 @@
 from django.conf import settings
 from django.http import HttpResponseRedirect
+from django.http import HttpResponseRedirect
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework import status
+
+from .serializers import RoleSerializer
+from .models import Role
 
 
 def email_confirm_redirect(request, key):
@@ -12,3 +20,40 @@ def password_reset_confirm_redirect(request, uidb64, token):
     return HttpResponseRedirect(
         f"{settings.PASSWORD_RESET_CONFIRM_REDIRECT_BASE_URL}{uidb64}/{token}/"
     )
+
+
+@api_view(['GET', 'POST'])
+@permission_classes([IsAuthenticated])
+def role_list(request):
+    if request.method == 'GET':
+        roles = Role.objects.all()
+        serializer = RoleSerializer(roles, many=True)
+        return Response(serializer.data)
+    elif request.method == 'POST':
+        serializer = RoleSerializer(data=request.data)
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+@api_view(['GET', 'PUT', 'DELETE'])
+@permission_classes([IsAuthenticated])
+def role_detail(request, pk):
+    try:
+        role = Role.objects.get(pk=pk)
+    except Role.DoesNotExist:
+        return Response({'error': 'Role not found'}, status=status.HTTP_404_NOT_FOUND)
+
+    if request.method == 'GET':
+        serializer = RoleSerializer(role)
+        return Response(serializer.data)
+    elif request.method == 'PUT':
+        serializer = RoleSerializer(role, data=request.data, partial=True)
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+    elif request.method == 'DELETE':
+        role.delete()
+        return Response({'deleted': True}, status=status.HTTP_204_NO_CONTENT)

--- a/treeHouse/settings.py
+++ b/treeHouse/settings.py
@@ -142,7 +142,7 @@ AUTH_USER_MODEL = 'authentication.CustomUser'
 
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 EMAIL_CONFIRM_REDIRECT_BASE_URL = os.getenv("EMAIL_CONFIRM_REDIRECT_BASE_URL", "http://localhost:8000/email-confirm/")
-PASSWORD_RESET_CONFIRM_REDIRECT_BASE_URL = os.getenv("PASSWORD_RESET_CONFIRM_REDIRECT_BASE_URL",
+PASSWORD_RESET_CONFIRM_REDIRECT_BASE_URL = os.getenv("PASSWORD_RESET_CONFIRM_REDIRECT_BASE_URL", "http://localhost:8000/password-reset-confirm/")
 
 # Internationalization
 # https://docs.djangoproject.com/en/5.1/topics/i18n/


### PR DESCRIPTION
## Summary by Sourcery

Introduce CRUD API endpoints for the Role model secured by authentication, add serialization and URL routing, and cover functionality with dedicated tests.

New Features:
- Add authenticated API view for listing and creating roles at /roles/
- Add authenticated API view for retrieving, updating, and deleting individual roles at /roles/<id>/
- Introduce RoleSerializer for Role model serialization and validation

Tests:
- Add APITestCase for Role API covering GET, POST on list endpoint and GET, PUT, DELETE on detail endpoint

Chores:
- Update default PASSWORD_RESET_CONFIRM_REDIRECT_BASE_URL in settings to use environment variable