### PR TITLE
Add admin user impersonation and logging

### DIFF
--- a/monitoring/authentication.py
+++ b/monitoring/authentication.py
@@ -1,0 +1,56 @@
+from rest_framework.authentication import TokenAuthentication
+from rest_framework.exceptions import AuthenticationFailed, PermissionDenied
+
+
+class ImpersonatingTokenAuthentication(TokenAuthentication):
+    """
+    Extends standard token auth to support admin impersonation.
+
+    Usage: include the header on any request:
+        X-Impersonate-User: <target_user_pk>
+
+    Rules:
+    - The requester must be an active admin (is_staff=True).
+    - The target user must be active and non-admin.
+    - Every impersonated request is written to ImpersonationLog.
+    - request._impersonating_admin is set so views can inspect it if needed.
+    """
+
+    def authenticate(self, request):
+        result = super().authenticate(request)
+        if result is None:
+            return None
+
+        user, token = result
+        target_pk = request.META.get('HTTP_X_IMPERSONATE_USER')
+
+        if not target_pk:
+            return result
+
+        if not user.is_staff:
+            raise PermissionDenied('Only admins can impersonate users.')
+
+        from django.contrib.auth import get_user_model
+        User = get_user_model()
+
+        try:
+            target = User.objects.get(pk=target_pk, is_active=True)
+        except (User.DoesNotExist, ValueError):
+            raise AuthenticationFailed('Target user not found or inactive.')
+
+        if target.is_staff:
+            raise PermissionDenied('Cannot impersonate another admin.')
+
+        self._write_log(user, target, request)
+
+        request._impersonating_admin = user
+        return (target, token)
+
+    def _write_log(self, admin, target, request):
+        from monitoring.models import ImpersonationLog
+        ImpersonationLog.objects.create(
+            admin=admin,
+            target_user=target,
+            path=request.path,
+            method=request.method,
+        )

--- a/monitoring/migrations/0003_add_impersonation_log.py
+++ b/monitoring/migrations/0003_add_impersonation_log.py
@@ -1,0 +1,36 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('monitoring', '0002_seed_alert_rules'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ImpersonationLog',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('admin', models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE,
+                    related_name='impersonation_actions',
+                    to=settings.AUTH_USER_MODEL,
+                )),
+                ('target_user', models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE,
+                    related_name='impersonated_by',
+                    to=settings.AUTH_USER_MODEL,
+                )),
+                ('path', models.CharField(max_length=255)),
+                ('method', models.CharField(max_length=10)),
+                ('timestamp', models.DateTimeField(auto_now_add=True)),
+            ],
+            options={
+                'ordering': ['-timestamp'],
+            },
+        ),
+    ]

--- a/monitoring/models.py
+++ b/monitoring/models.py
@@ -87,3 +87,25 @@ class AlertInstance(models.Model):
 
     def __str__(self):
         return f"Alert: {self.rule.name} @ {self.triggered_at} ({self.status})"
+
+
+class ImpersonationLog(models.Model):
+    admin = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name='impersonation_actions',
+    )
+    target_user = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name='impersonated_by',
+    )
+    path = models.CharField(max_length=255)
+    method = models.CharField(max_length=10)
+    timestamp = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ['-timestamp']
+
+    def __str__(self):
+        return f"{self.admin.username} as {self.target_user.username} [{self.method} {self.path}]"

--- a/monitoring/serializers.py
+++ b/monitoring/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from .models import SystemMetric, AlertRule, AlertInstance
+from .models import SystemMetric, AlertRule, AlertInstance, ImpersonationLog
 
 
 class SystemMetricSerializer(serializers.ModelSerializer):
@@ -40,4 +40,23 @@ class AlertInstanceSerializer(serializers.ModelSerializer):
     def get_acknowledged_by_username(self, obj):
         if obj.acknowledged_by:
             return obj.acknowledged_by.username
+        return None
+
+
+class ImpersonationLogSerializer(serializers.ModelSerializer):
+    admin_username = serializers.CharField(source='admin.username', read_only=True)
+    target_username = serializers.CharField(source='target_user.username', read_only=True)
+    target_role = serializers.SerializerMethodField()
+
+    class Meta:
+        model = ImpersonationLog
+        fields = [
+            'id', 'admin', 'admin_username',
+            'target_user', 'target_username', 'target_role',
+            'path', 'method', 'timestamp',
+        ]
+
+    def get_target_role(self, obj):
+        if obj.target_user.role:
+            return obj.target_user.role.name
         return None

--- a/monitoring/tests.py
+++ b/monitoring/tests.py
@@ -3,7 +3,7 @@ from rest_framework.test import APIClient
 from rest_framework.authtoken.models import Token
 
 from authentication.models import CustomUser, Role
-from .models import SystemMetric, AlertRule, AlertInstance
+from .models import SystemMetric, AlertRule, AlertInstance, ImpersonationLog
 
 
 def make_user(username, role_name):
@@ -356,3 +356,127 @@ class MonitoringDashboardTestCase(TestCase):
         response = self.client.get('/api/monitoring/dashboard/')
         self.assertEqual(response.data['health_status'], 'healthy')
         self.assertEqual(response.data['active_alert_counts']['critical'], 0)
+
+
+class ImpersonationTestCase(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.admin = make_admin('admin_imp')
+        self.admin_token = Token.objects.create(user=self.admin)
+        self.tenant = make_user('tenant_imp', Role.TENANT)
+        self.tenant_token = Token.objects.create(user=self.tenant)
+        self.landlord = make_user('landlord_imp', Role.LANDLORD)
+        self.landlord_token = Token.objects.create(user=self.landlord)
+
+    def _impersonate(self, target_pk):
+        return {
+            'HTTP_AUTHORIZATION': f'Token {self.admin_token.key}',
+            'HTTP_X_IMPERSONATE_USER': str(target_pk),
+        }
+
+    def test_admin_can_impersonate_tenant(self):
+        response = self.client.get(
+            '/api/auth/me/',
+            **self._impersonate(self.tenant.pk),
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['username'], self.tenant.username)
+
+    def test_admin_can_impersonate_landlord(self):
+        response = self.client.get(
+            '/api/auth/me/',
+            **self._impersonate(self.landlord.pk),
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['username'], self.landlord.username)
+
+    def test_impersonation_logs_request(self):
+        self.client.get('/api/auth/me/', **self._impersonate(self.tenant.pk))
+        log = ImpersonationLog.objects.filter(
+            admin=self.admin, target_user=self.tenant
+        ).first()
+        self.assertIsNotNone(log)
+        self.assertEqual(log.method, 'GET')
+        self.assertEqual(log.path, '/api/auth/me/')
+
+    def test_non_admin_cannot_impersonate(self):
+        response = self.client.get(
+            '/api/auth/me/',
+            HTTP_AUTHORIZATION=f'Token {self.tenant_token.key}',
+            HTTP_X_IMPERSONATE_USER=str(self.landlord.pk),
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_cannot_impersonate_another_admin(self):
+        other_admin = make_admin('admin_imp2')
+        Token.objects.create(user=other_admin)
+        response = self.client.get(
+            '/api/auth/me/',
+            **self._impersonate(other_admin.pk),
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_cannot_impersonate_nonexistent_user(self):
+        response = self.client.get(
+            '/api/auth/me/',
+            **self._impersonate(99999),
+        )
+        # AuthenticationFailed → 401
+        self.assertEqual(response.status_code, 401)
+
+    def test_cannot_impersonate_inactive_user(self):
+        self.tenant.is_active = False
+        self.tenant.save()
+        response = self.client.get(
+            '/api/auth/me/',
+            **self._impersonate(self.tenant.pk),
+        )
+        # AuthenticationFailed → 401
+        self.assertEqual(response.status_code, 401)
+
+    def test_no_header_uses_own_identity(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.admin_token.key}')
+        response = self.client.get('/api/auth/me/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['username'], self.admin.username)
+
+
+class ImpersonationLogListTestCase(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.admin = make_admin('admin_logs')
+        self.admin_token = Token.objects.create(user=self.admin)
+        self.tenant = make_user('tenant_logs', Role.TENANT)
+        self.tenant_token = Token.objects.create(user=self.tenant)
+        ImpersonationLog.objects.create(
+            admin=self.admin, target_user=self.tenant,
+            path='/api/billing/invoices/', method='GET',
+        )
+
+    def test_admin_can_list_logs(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.admin_token.key}')
+        response = self.client.get('/api/monitoring/impersonation-logs/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['admin_username'], self.admin.username)
+        self.assertEqual(response.data[0]['target_username'], self.tenant.username)
+
+    def test_non_admin_forbidden(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.tenant_token.key}')
+        response = self.client.get('/api/monitoring/impersonation-logs/')
+        self.assertEqual(response.status_code, 403)
+
+    def test_filter_by_target_user(self):
+        other = make_user('other_logs', Role.TENANT)
+        Token.objects.create(user=other)
+        ImpersonationLog.objects.create(
+            admin=self.admin, target_user=other,
+            path='/api/auth/me/', method='GET',
+        )
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.admin_token.key}')
+        response = self.client.get(
+            f'/api/monitoring/impersonation-logs/?target_user={self.tenant.pk}'
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['target_username'], self.tenant.username)

--- a/monitoring/urls.py
+++ b/monitoring/urls.py
@@ -8,4 +8,5 @@ urlpatterns = [
     path('alerts/', views.alert_list, name='monitoring-alert-list'),
     path('alerts/<int:pk>/', views.alert_detail, name='monitoring-alert-detail'),
     path('dashboard/', views.monitoring_dashboard, name='monitoring-dashboard'),
+    path('impersonation-logs/', views.impersonation_log_list, name='monitoring-impersonation-logs'),
 ]

--- a/monitoring/views.py
+++ b/monitoring/views.py
@@ -5,8 +5,11 @@ from rest_framework.response import Response
 from rest_framework import status
 from drf_spectacular.utils import extend_schema, OpenApiParameter, OpenApiExample
 
-from .models import SystemMetric, AlertRule, AlertInstance
-from .serializers import SystemMetricSerializer, AlertRuleSerializer, AlertInstanceSerializer
+from .models import SystemMetric, AlertRule, AlertInstance, ImpersonationLog
+from .serializers import (
+    SystemMetricSerializer, AlertRuleSerializer, AlertInstanceSerializer,
+    ImpersonationLogSerializer,
+)
 
 
 def _is_admin(user):
@@ -218,6 +221,41 @@ def alert_detail(request, pk):
         instance.save()
 
     return Response(AlertInstanceSerializer(instance).data)
+
+
+# ---------------------------------------------------------------------------
+# Monitoring Dashboard
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Impersonation Logs
+# ---------------------------------------------------------------------------
+
+@extend_schema(
+    methods=['GET'],
+    summary="List impersonation logs",
+    parameters=[
+        OpenApiParameter('target_user', int, description='Filter by target user PK'),
+        OpenApiParameter('hours', int, description='Lookback window in hours (default 72)'),
+    ],
+)
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
+def impersonation_log_list(request):
+    if not _is_admin(request.user):
+        return Response({'detail': 'Admin access required.'}, status=status.HTTP_403_FORBIDDEN)
+
+    hours = int(request.query_params.get('hours', 72))
+    since = timezone.now() - timezone.timedelta(hours=hours)
+    qs = ImpersonationLog.objects.select_related(
+        'admin', 'target_user', 'target_user__role'
+    ).filter(timestamp__gte=since)
+
+    target_pk = request.query_params.get('target_user')
+    if target_pk:
+        qs = qs.filter(target_user__pk=target_pk)
+
+    return Response(ImpersonationLogSerializer(qs, many=True).data)
 
 
 # ---------------------------------------------------------------------------

--- a/treeHouse/settings.py
+++ b/treeHouse/settings.py
@@ -139,7 +139,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
-        "rest_framework.authentication.TokenAuthentication",
+        "monitoring.authentication.ImpersonatingTokenAuthentication",
     ],
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
 }


### PR DESCRIPTION
Introduce admin impersonation support and audit logging.

- Add ImpersonatingTokenAuthentication to allow admins (is_staff) to impersonate active non-admin users via X-Impersonate-User header; sets request._impersonating_admin and logs each impersonated request.
- Add ImpersonationLog model and migration to record admin, target_user, path, method and timestamp.
- Expose impersonation logs via a new admin-only endpoint (/api/monitoring/impersonation-logs/) with optional filtering by target_user and lookback hours.
- Add serializer for ImpersonationLog and register the endpoint in urls/views.
- Add comprehensive tests for impersonation behavior, logging, permissions and list filtering.
- Switch REST framework default authentication class to the new ImpersonatingTokenAuthentication.

This enables admins to act on behalf of users for support/debugging while ensuring actions are auditable and restricted.