### PR TITLE
Add Docker setup and env-based settings

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+venv/
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.env
+.git/
+.gitignore
+*.log
+db.sqlite3
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.14-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libpq-dev \
+    gcc \
+    postgresql-client \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt gunicorn
+
+COPY . .
+
+RUN chmod +x entrypoint.sh
+
+EXPOSE 8000
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: ${DB_NAME}
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  web:
+    build: .
+    ports:
+      - "8000:8000"
+    env_file:
+      - .env
+    environment:
+      DB_HOST: db
+      DB_PORT: 5432
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: unless-stopped
+
+volumes:
+  postgres_data:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+echo "Waiting for postgres..."
+until pg_isready -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER"; do
+  sleep 1
+done
+echo "Postgres is ready."
+
+echo "Running migrations..."
+python manage.py migrate --noinput
+
+echo "Starting server..."
+exec gunicorn treeHouse.wsgi:application \
+    --bind 0.0.0.0:8000 \
+    --workers 3 \
+    --timeout 120

--- a/treeHouse/settings.py
+++ b/treeHouse/settings.py
@@ -25,10 +25,10 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-kxl)=hx4!zivkfy0@g7^r3ubn87x_n+6)k++3uqzy&v9l!2y3('
+SECRET_KEY = os.getenv('SECRET_KEY', 'django-insecure-kxl)=hx4!zivkfy0@g7^r3ubn87x_n+6)k++3uqzy&v9l!2y3(')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.getenv('DEBUG', 'True') == 'True'
 
 ALLOWED_HOSTS = ['localhost', '127.0.0.1', '*']
 


### PR DESCRIPTION
Add containerization for the project: .dockerignore, Dockerfile, docker-compose.yml and entrypoint.sh. Dockerfile installs system deps, Python requirements and gunicorn, exposes port 8000 and uses entrypoint.sh. docker-compose.yml defines a Postgres service with healthcheck and a web service that depends on it, plus a named volume for DB data. entrypoint.sh waits for Postgres, runs migrations, and starts gunicorn. Also update treeHouse/settings.py to read SECRET_KEY and DEBUG from environment variables (with sensible defaults) so the app can be configured in containers.

## Summary by Sourcery

Containerize the Django app with Docker and docker-compose and make core settings configurable via environment variables.

New Features:
- Introduce a Dockerfile and entrypoint script to build and run the web application with Gunicorn in a container.
- Add a docker-compose configuration to run the web service alongside a Postgres database with persistent storage.

Enhancements:
- Make SECRET_KEY and DEBUG in Django settings configurable through environment variables for easier environment-specific configuration.

Build:
- Add .dockerignore to optimize Docker build context and image size.

Deployment:
- Define containerized runtime configuration for the web app and database using Docker and docker-compose.