### PR TITLE
Serve media files in development

### DIFF
--- a/treeHouse/settings.py
+++ b/treeHouse/settings.py
@@ -192,6 +192,10 @@ USE_TZ = True
 
 STATIC_URL = 'static/'
 
+# Media files (User uploads)
+MEDIA_URL = 'media/'
+MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.1/ref/settings/#default-auto-field
 

--- a/treeHouse/urls.py
+++ b/treeHouse/urls.py
@@ -17,8 +17,11 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import include, path, re_path
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView, SpectacularRedocView
+from django.conf import settings
+from django.conf.urls.static import static
 
 urlpatterns = [
+	
     path('admin/', admin.site.urls),
     path('api/auth/', include('authentication.urls')),
 
@@ -36,3 +39,5 @@ urlpatterns = [
     path('api/dashboard/', include('dashboard.urls')),
     path('api/monitoring/', include('monitoring.urls')),
 ]
+if settings.DEBUG:
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
Add MEDIA_URL and MEDIA_ROOT to settings to support user-uploaded media (media/ directory). Update urls.py to import settings and static, and append a static() route serving MEDIA_URL from MEDIA_ROOT when DEBUG is True so media files are served during development.

## Summary by Sourcery

Serve user-uploaded media files during development by configuring media settings and URLs.

New Features:
- Add MEDIA_URL and MEDIA_ROOT settings to support user-uploaded media storage.
- Expose media files via a static URL route when running in DEBUG mode.