### PR TITLE
Add media volume and serve media in dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN pip install --no-cache-dir -r requirements.txt gunicorn
 
 COPY . .
 
-RUN chmod +x entrypoint.sh
+RUN chmod +x entrypoint.sh && mkdir -p /app/media
 
 EXPOSE 8000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
     environment:
       DB_HOST: db
       DB_PORT: 5432
+    volumes:
+      - media_files:/app/media
     depends_on:
       db:
         condition: service_healthy
@@ -30,3 +32,4 @@ services:
 
 volumes:
   postgres_data:
+  media_files:

--- a/treeHouse/urls.py
+++ b/treeHouse/urls.py
@@ -16,9 +16,9 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import include, path, re_path
-from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView, SpectacularRedocView
 from django.conf import settings
 from django.conf.urls.static import static
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView, SpectacularRedocView
 
 urlpatterns = [
 	
@@ -39,5 +39,7 @@ urlpatterns = [
     path('api/dashboard/', include('dashboard.urls')),
     path('api/monitoring/', include('monitoring.urls')),
 ]
+
+# Serve media files in development
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
Create /app/media in the container and mount a persistent media_files volume in docker-compose so uploaded media is persisted. Update Dockerfile to make entrypoint executable and ensure the media directory exists. Expose the media_files volume in docker-compose and add Django static serving for MEDIA_URL when DEBUG is true (also minor import reordering in treeHouse/urls.py). This enables serving uploaded media in development and persistence across container restarts.

## Summary by Sourcery

Serve uploaded media files in development and persist them across Docker container restarts.

Enhancements:
- Enable Django to serve MEDIA_URL content from MEDIA_ROOT when DEBUG is true for local development.
- Ensure the application Docker image creates the /app/media directory and has an executable entrypoint script.

Deployment:
- Mount a persistent media_files volume at /app/media in docker-compose to store uploaded media across container restarts.