### PR TITLE
Add detail endpoints for images and lease docs

### DIFF
--- a/docs/api-integration.md
+++ b/docs/api-integration.md
@@ -29,6 +29,7 @@ Content-Type: `application/json`
 | Create / update unit | ✗ | ✓ | Own | Assigned | ✗ | ✗ | ✗ |
 | Delete unit | ✗ | ✓ | Own | ✗ | ✗ | ✗ | ✗ |
 | Upload unit images | ✗ | ✓ | Own | Assigned | ✗ | ✗ | ✗ |
+| Delete unit images | ✗ | ✓ | Own | Assigned | ✗ | ✗ | ✗ |
 | Appoint / remove agent | ✗ | ✓ | Own | ✗ | ✗ | ✗ | ✗ |
 | Portfolio dashboard | ✗ | All | Own | ✗ | ✗ | ✗ | ✗ |
 | **— APPLICATIONS —** | | | | | | | |
@@ -39,6 +40,7 @@ Content-Type: `application/json`
 | **— LEASES & DOCUMENTS —** | | | | | | | |
 | View / create lease | ✗ | ✓ | Own | Assigned | ✗ | ✗ | ✗ |
 | List / upload lease documents | ✗ | ✓ | Own | Assigned | On lease | ✗ | ✗ |
+| Delete lease documents | ✗ | ✓ | Own | Assigned | ✗ | ✗ | ✗ |
 | Sign lease document | ✗ | ✗ | ✗ | ✗ | On lease | ✗ | ✗ |
 | **— BILLING —** | | | | | | | |
 | Configure billing | ✗ | ✓ | Own | ✗ | ✗ | ✗ | ✗ |
@@ -1154,7 +1156,30 @@ Accepting a bid automatically:
 
 ---
 
-### Images
+### Images on Unit
+`GET /api/property/units/<unit_id>/images/` — list all images for a unit
+`POST /api/property/units/<unit_id>/images/` — upload a new image (Admin / Owner / Agent)
+```json
+// POST Request — multipart/form-data
+{ "image": <binary_file> }
+
+// Response 201
+{
+  "id": 1,
+  "property": 1,
+  "image": "/media/property_images/unit_a1.jpg",
+  "uploaded_at": "2024-03-01T09:05:00Z"
+}
+```
+
+`GET /api/property/units/<unit_id>/images/<image_id>/` — get image detail
+`DELETE /api/property/units/<unit_id>/images/<image_id>/` — delete image (Admin / Owner / Agent) → `204 No Content`
+
+> When deleting an image, only the Admin, property owner, or assigned agent can proceed. Similar filenames automatically receive a suffix to prevent overwrites (e.g., `photo.jpg` → `photo_1.jpg`).
+
+---
+
+### Images on Maintenance Request
 `GET /api/maintenance/requests/<pk>/images/`
 `POST /api/maintenance/requests/<pk>/images/` — `multipart/form-data`
 
@@ -1209,6 +1234,29 @@ Attached to a specific lease. Stores a URL to the document (no file upload — s
 }
 ```
 Document type choices: `lease_agreement`, `addendum`, `notice`, `inspection_report`, `other`
+
+### Get a Document (Owner / Agent / Tenant on that lease)
+`GET /api/property/leases/<lease_id>/documents/<doc_id>/`
+
+```json
+// Response 200
+{
+  "id": 1,
+  "lease": 2,
+  "document_type": "lease_agreement",
+  "title": "Lease Agreement — Unit A1 2024",
+  "file_url": "https://storage.example.com/docs/lease-a1-2024.pdf",
+  "uploaded_by": 3,
+  "signed_by": 5,
+  "signed_at": "2024-02-01T10:00:00Z",
+  "created_at": "2024-02-01T08:00:00Z"
+}
+```
+
+### Delete a Document (Owner / Agent only)
+`DELETE /api/property/leases/<lease_id>/documents/<doc_id>/` → `204 No Content`
+
+Only the property owner or assigned agent can delete documents. Tenants cannot delete.
 
 ### Sign a Document (Tenant on that lease)
 `POST /api/property/leases/<lease_id>/documents/<doc_id>/sign/`

--- a/property/urls.py
+++ b/property/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     path('properties/<int:property_id>/agents/<int:agent_id>/', views.property_agent_detail, name='property-agent-detail'),
     path('units/<int:pk>/', views.unit_detail, name='unit-detail'),
     path('units/<int:unit_id>/images/', views.unit_image_list_create, name='unit-image-list-create'),
+    path('units/<int:unit_id>/images/<int:image_id>/', views.unit_image_detail, name='unit-image-detail'),
     path('units/<int:unit_id>/lease/', views.lease_list_create, name='lease-list-create'),
     path('units/public/', views.public_units, name='public-units'),
     # Tenant applications
@@ -18,6 +19,7 @@ urlpatterns = [
     path('dashboard/', views.landlord_dashboard, name='landlord-dashboard'),
     # Lease documents
     path('leases/<int:lease_id>/documents/', views.lease_document_list_create, name='lease-document-list-create'),
+    path('leases/<int:lease_id>/documents/<int:doc_id>/', views.lease_document_detail, name='lease-document-detail'),
     path('leases/<int:lease_id>/documents/<int:doc_id>/sign/', views.lease_document_sign, name='lease-document-sign'),
     # Property reviews
     path('properties/<int:property_id>/reviews/', views.property_review_list_create, name='property-review-list-create'),

--- a/property/views.py
+++ b/property/views.py
@@ -233,6 +233,32 @@ def unit_image_list_create(request, unit_id):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
+@extend_schema(methods=['GET'], summary="Get an image")
+@extend_schema(methods=['DELETE'], summary="Delete an image")
+@api_view(['GET', 'DELETE'])
+@permission_classes([IsAuthenticated])
+def unit_image_detail(request, unit_id, image_id):
+    try:
+        unit = Unit.objects.get(pk=unit_id)
+    except Unit.DoesNotExist:
+        return Response({'detail': 'Unit not found.'}, status=status.HTTP_404_NOT_FOUND)
+
+    try:
+        image = PropertyImage.objects.get(pk=image_id, property=unit.property)
+    except PropertyImage.DoesNotExist:
+        return Response({'detail': 'Image not found.'}, status=status.HTTP_404_NOT_FOUND)
+
+    if request.method == 'GET':
+        serializer = PropertyImageSerializer(image)
+        return Response(serializer.data)
+
+    elif request.method == 'DELETE':
+        if not (is_admin(request.user) or unit.property.owner == request.user or is_agent_for(request.user, unit.property)):
+            return Response({'detail': 'Permission denied.'}, status=status.HTTP_403_FORBIDDEN)
+        image.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
 @extend_schema(methods=['GET'], summary="Get lease for a unit")
 @extend_schema(
     methods=['POST'],
@@ -752,6 +778,40 @@ def lease_document_list_create(request, lease_id):
             serializer.save(lease=lease, uploaded_by=request.user)
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+@extend_schema(methods=['GET'], summary="Get a lease document")
+@extend_schema(methods=['DELETE'], summary="Delete a lease document")
+@api_view(['GET', 'DELETE'])
+@permission_classes([IsAuthenticated])
+def lease_document_detail(request, lease_id, doc_id):
+    try:
+        lease = Lease.objects.select_related('unit__property', 'tenant').get(pk=lease_id)
+    except Lease.DoesNotExist:
+        return Response({'detail': 'Lease not found.'}, status=status.HTTP_404_NOT_FOUND)
+
+    try:
+        doc = LeaseDocument.objects.select_related('uploaded_by').get(pk=doc_id, lease=lease)
+    except LeaseDocument.DoesNotExist:
+        return Response({'detail': 'Document not found.'}, status=status.HTTP_404_NOT_FOUND)
+
+    prop = lease.unit.property
+    is_owner = prop.owner == request.user
+    is_assigned_agent = is_agent_for(request.user, prop)
+    is_lease_tenant = lease.tenant == request.user
+
+    if not (is_admin(request.user) or is_owner or is_assigned_agent or is_lease_tenant):
+        return Response({'detail': 'Permission denied.'}, status=status.HTTP_403_FORBIDDEN)
+
+    if request.method == 'GET':
+        serializer = LeaseDocumentSerializer(doc)
+        return Response(serializer.data)
+
+    elif request.method == 'DELETE':
+        if not (is_admin(request.user) or is_owner or is_assigned_agent):
+            return Response({'detail': 'Only the landlord or assigned agent can delete documents.'}, status=status.HTTP_403_FORBIDDEN)
+        doc.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 @extend_schema(


### PR DESCRIPTION
Expose detail routes and view handlers for unit images and lease documents. Added URL patterns for GET/DELETE on /units/<unit_id>/images/<image_id>/ and /leases/<lease_id>/documents/<doc_id>/, and implemented unit_image_detail and lease_document_detail views. Both endpoints require authentication, return 404 for missing objects, and enforce permissions: image deletion limited to admins, property owners, or assigned agents; lease document GET allowed for admins, owners, assigned agents or the lease tenant, while deletion is restricted to admins, owners or assigned agents. Lease lookup uses select_related to optimize queries.

## Summary by Sourcery

Add authenticated detail endpoints for unit images and lease documents with appropriate permission checks for retrieval and deletion.

New Features:
- Introduce GET/DELETE detail endpoint for unit images scoped to a unit and its property.
- Introduce GET/DELETE detail endpoint for lease documents scoped to a lease with optimized related lookups.

Enhancements:
- Enforce role-based access control on unit image deletion for admins, property owners, and assigned agents.
- Enforce role- and role-plus-tenant-based access control on lease document retrieval and deletion.