### PR TITLE
feat(property): tenant invitations, accept flow, and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,7 @@ SECRET_KEY=
 # Email redirect URLs (used by dj-rest-auth verification flows)
 EMAIL_CONFIRM_REDIRECT_BASE_URL=http://localhost:8000/email-confirm/
 PASSWORD_RESET_CONFIRM_REDIRECT_BASE_URL=http://localhost:8000/password-reset-confirm/
+TENANT_INVITE_REDIRECT_BASE_URL=http://localhost:3000/tenant-invite/
 DEFAULT_FROM_EMAIL=noreply@yourdomain.com
 
 # Stripe — use placeholders for local dev without payment testing

--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,12 @@ PASSWORD_RESET_CONFIRM_REDIRECT_BASE_URL=http://localhost:8000/password-reset-co
 TENANT_INVITE_REDIRECT_BASE_URL=http://localhost:3000/tenant-invite/
 DEFAULT_FROM_EMAIL=noreply@yourdomain.com
 
+# Mailgun (optional — if unset, email prints to console in dev)
+# Use an address on your verified domain for DEFAULT_FROM_EMAIL (e.g. noreply@mg.yourdomain.com)
+MAILGUN_API_KEY=
+MAILGUN_SENDER_DOMAIN=mg.yourdomain.com
+# MAILGUN_EU=true
+
 # Stripe — use placeholders for local dev without payment testing
 STRIPE_SECRET_KEY=sk_test_placeholder
 STRIPE_WEBHOOK_SECRET=whsec_placeholder

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,11 +30,16 @@ EMAIL_CONFIRM_REDIRECT_BASE_URL=
 PASSWORD_RESET_CONFIRM_REDIRECT_BASE_URL=
 TENANT_INVITE_REDIRECT_BASE_URL=
 DEFAULT_FROM_EMAIL=
+MAILGUN_API_KEY=
+MAILGUN_SENDER_DOMAIN=
+# MAILGUN_EU=true
 STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=
 ```
 
 Stripe keys use `sk_test_placeholder` / `whsec_placeholder` as defaults until real keys are added.
+
+**Email:** With both `MAILGUN_API_KEY` and `MAILGUN_SENDER_DOMAIN` set, Django sends via [Mailgun](https://www.mailgun.com/) (`django-anymail`). Otherwise email uses the console backend in dev. Set `DEFAULT_FROM_EMAIL` to an address on your verified Mailgun domain (e.g. `noreply@mg.example.com`). For Mailgun EU hosting, set `MAILGUN_EU=true`.
 
 DB connects via Supabase transaction pooler (`aws-1-eu-west-1.pooler.supabase.com:5432`). If connection fails, check that the Supabase project is not paused (free tier pauses after inactivity).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ DB_HOST=
 DB_PORT=
 EMAIL_CONFIRM_REDIRECT_BASE_URL=
 PASSWORD_RESET_CONFIRM_REDIRECT_BASE_URL=
+TENANT_INVITE_REDIRECT_BASE_URL=
 DEFAULT_FROM_EMAIL=
 STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=
@@ -75,11 +76,11 @@ authentication/     # user management app
   adapter.py        # CustomAccountAdapter — saves extra fields on registration
   migrations/       # 0004 seeds roles, 0005 adds ArtisanProfile, 0006 seeds Artisan role, 0008 adds MovingCompanyProfile, 0009 seeds MovingCompany role
 property/           # property management app
-  models.py         # Property, Unit, Lease, PropertyImage, PropertyAgent, TenantApplication
+  models.py         # Property, Unit, Lease, PropertyImage, PropertyAgent, TenantApplication, TenantInvitation
   serializers.py    # serializers for all models
   views.py          # CRUD views + permission helpers (is_landlord, is_admin, is_agent_for) + dashboard
   urls.py           # all URL patterns under /api/property/
-  migrations/       # 0005 adds PropertyAgent, 0006 adds TenantApplication
+  migrations/       # 0005 adds PropertyAgent, 0006 adds TenantApplication, 0009 adds TenantInvitation
 billing/            # rent collection, invoicing, expenses, and reporting app
   models.py         # BillingConfig, Invoice, Payment, Receipt, ReminderLog, ChargeType, AdditionalIncome, Expense
   serializers.py    # serializers for all models
@@ -145,6 +146,7 @@ templates/          # Django templates directory
 ## Auth Flow
 - Registration: `POST /api/auth/register/` — creates user, triggers email verification (console backend in dev)
 - Login: `POST /api/auth/login/` — returns a Token
+- Tenant invite accept: `POST /api/auth/tenant-invite/accept/` — no auth; body includes invitation `token` and `password`; creates tenant user, profile, lease, returns auth `key` (same as login)
 - All protected endpoints require: `Authorization: Token <token>`
 
 ## Roles
@@ -163,6 +165,7 @@ Seeded via data migrations. Roles are:
 |--------|-----|-------------|
 | POST | `/api/auth/register/` | Register new user |
 | POST | `/api/auth/login/` | Login, returns token |
+| POST | `/api/auth/tenant-invite/accept/` | Accept tenant invitation (no auth); returns token key + user |
 | POST | `/api/auth/logout/` | Logout |
 | GET | `/api/auth/user/` | Current user details (dj-rest-auth) |
 | POST | `/api/auth/password/reset/` | Request password reset email |
@@ -199,6 +202,8 @@ Seeded via data migrations. Roles are:
 | DELETE | `/api/property/units/<pk>/` | Admin, owner only |
 | GET/POST | `/api/property/units/<pk>/images/` | GET=any, POST=admin/owner/agent |
 | GET/POST | `/api/property/units/<pk>/lease/` | Admin, owner, assigned agent |
+| GET/POST | `/api/property/units/<pk>/tenant-invitations/` | List/create invites — owner or assigned agent; if email matches existing Tenant, creates lease instead of invite |
+| POST | `/api/property/tenant-invitations/<pk>/resend/` | Owner or assigned agent — new token + email |
 | GET | `/api/property/units/public/` | No auth required |
 | GET/POST | `/api/property/applications/` | Landlord=own units, Tenant=own, Admin=all |
 | GET/PUT | `/api/property/applications/<pk>/` | Landlord: approve/reject — Tenant: withdraw |

--- a/authentication/urls.py
+++ b/authentication/urls.py
@@ -8,6 +8,7 @@ from dj_rest_auth.views import (
     PasswordResetView,
 )
 from authentication.views import email_confirm_redirect, password_reset_confirm_redirect
+from property.views import tenant_invitation_accept
 from dj_rest_auth.registration.views import RegisterView
 from dj_rest_auth.views import LoginView, LogoutView, UserDetailsView
 from django.urls import path
@@ -82,6 +83,7 @@ _password_reset_confirm_view = extend_schema(
 
 
 urlpatterns = [
+    path("tenant-invite/accept/", tenant_invitation_accept, name="tenant-invite-accept"),
     path("register/", _register_view.as_view(), name="rest_register"),
     path("login/", _login_view.as_view(), name="rest_login"),
     path("logout/", LogoutView.as_view(), name="rest_logout"),

--- a/docs/api-integration.md
+++ b/docs/api-integration.md
@@ -14,6 +14,7 @@ Content-Type: `application/json`
 |--------|:------:|:-----:|:--------:|:-----:|:------:|:-------:|:-------------:|
 | **— ACCOUNT —** | | | | | | |
 | Register / Login / Logout | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Accept tenant invitation (no auth) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | View & update own account | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | View & update own role profile | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Change password | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
@@ -37,6 +38,8 @@ Content-Type: `application/json`
 | List applications | ✗ | All | Own units | ✗ | Own | ✗ | ✗ |
 | Approve / reject application | ✗ | ✓ | Own units | ✗ | ✗ | ✗ | ✗ |
 | Withdraw application | ✗ | ✗ | ✗ | ✗ | Own | ✗ | ✗ |
+| List / create tenant invitations (per unit) | ✗ | All | Own units | Assigned | ✗ | ✗ | ✗ |
+| Resend tenant invitation | ✗ | All | Own units | Assigned | ✗ | ✗ | ✗ |
 | **— LEASES & DOCUMENTS —** | | | | | | | |
 | View / create lease | ✗ | ✓ | Own | Assigned | ✗ | ✗ | ✗ |
 | List / upload lease documents | ✗ | ✓ | Own | Assigned | On lease | ✗ | ✗ |
@@ -157,6 +160,31 @@ Content-Type: `application/json`
 Store the token and include it on every subsequent request:
 ```
 Authorization: Token abc123tokenhere
+```
+
+---
+
+### Accept tenant invitation
+`POST /api/auth/tenant-invite/accept/` — **no** `Authorization` header. Use the `token` value from the invite email (query string on the frontend URL is for UX only; the API expects `token` in the JSON body).
+
+```json
+// Request
+{
+  "token": "<url-safe-token-from-email>",
+  "password": "strongpass123",
+  "first_name": "Jane",
+  "last_name": "Doe",
+  "phone": "+254712345678",
+  "national_id": "",
+  "emergency_contact_name": "",
+  "emergency_contact_phone": ""
+}
+
+// Response 201
+{
+  "key": "abc123tokenhere",
+  "user": { "pk": 1, "username": "jane@example.com", "email": "jane@example.com", "role": 2, "...": "..." }
+}
 ```
 
 ---

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -60,6 +60,11 @@ PASSWORD_RESET_CONFIRM_REDIRECT_BASE_URL=http://localhost:8000/password-reset-co
 TENANT_INVITE_REDIRECT_BASE_URL=http://localhost:3000/tenant-invite/
 DEFAULT_FROM_EMAIL=noreply@yourdomain.com
 
+# Mailgun (optional — omit both to keep console email in dev)
+MAILGUN_API_KEY=
+MAILGUN_SENDER_DOMAIN=mg.yourdomain.com
+# MAILGUN_EU=true
+
 # Stripe (use placeholders for local dev — real keys needed for payment testing)
 STRIPE_SECRET_KEY=sk_test_placeholder
 STRIPE_WEBHOOK_SECRET=whsec_placeholder

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -57,6 +57,7 @@ SECRET_KEY=<generate-a-long-random-string>
 # Email (redirect URLs for email verification and password reset flows)
 EMAIL_CONFIRM_REDIRECT_BASE_URL=http://localhost:8000/email-confirm/
 PASSWORD_RESET_CONFIRM_REDIRECT_BASE_URL=http://localhost:8000/password-reset-confirm/
+TENANT_INVITE_REDIRECT_BASE_URL=http://localhost:3000/tenant-invite/
 DEFAULT_FROM_EMAIL=noreply@yourdomain.com
 
 # Stripe (use placeholders for local dev — real keys needed for payment testing)

--- a/property/migrations/0009_tenant_invitation.py
+++ b/property/migrations/0009_tenant_invitation.py
@@ -1,0 +1,43 @@
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('property', '0008_add_search_features'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='TenantInvitation',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('email', models.EmailField(max_length=254)),
+                ('phone', models.CharField(blank=True, max_length=20)),
+                ('first_name', models.CharField(blank=True, max_length=150)),
+                ('last_name', models.CharField(blank=True, max_length=150)),
+                ('start_date', models.DateField()),
+                ('end_date', models.DateField(blank=True, null=True)),
+                ('rent_amount', models.DecimalField(decimal_places=2, max_digits=10)),
+                ('token_hash', models.CharField(max_length=64)),
+                ('status', models.CharField(choices=[('pending', 'Pending'), ('accepted', 'Accepted'), ('expired', 'Expired'), ('cancelled', 'Cancelled')], default='pending', max_length=20)),
+                ('expires_at', models.DateTimeField()),
+                ('accepted_at', models.DateTimeField(blank=True, null=True)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('accepted_user', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='accepted_tenant_invitations', to=settings.AUTH_USER_MODEL)),
+                ('invited_by', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='sent_tenant_invitations', to=settings.AUTH_USER_MODEL)),
+                ('unit', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='tenant_invitations', to='property.unit')),
+            ],
+        ),
+        migrations.AddConstraint(
+            model_name='tenantinvitation',
+            constraint=models.UniqueConstraint(
+                condition=models.Q(status='pending'),
+                fields=('unit', 'email'),
+                name='property_tenantinvitation_unit_email_pending_uniq',
+            ),
+        ),
+    ]

--- a/property/models.py
+++ b/property/models.py
@@ -188,3 +188,44 @@ class SavedSearch(models.Model):
 
     def __str__(self):
         return f"{self.user.username} — {self.name}"
+
+
+class TenantInvitation(models.Model):
+    STATUS_CHOICES = [
+        ('pending', 'Pending'),
+        ('accepted', 'Accepted'),
+        ('expired', 'Expired'),
+        ('cancelled', 'Cancelled'),
+    ]
+
+    unit = models.ForeignKey(Unit, on_delete=models.CASCADE, related_name='tenant_invitations')
+    email = models.EmailField()
+    phone = models.CharField(max_length=20, blank=True)
+    first_name = models.CharField(max_length=150, blank=True)
+    last_name = models.CharField(max_length=150, blank=True)
+    start_date = models.DateField()
+    end_date = models.DateField(null=True, blank=True)
+    rent_amount = models.DecimalField(max_digits=10, decimal_places=2)
+    invited_by = models.ForeignKey(
+        CustomUser, on_delete=models.CASCADE, related_name='sent_tenant_invitations'
+    )
+    token_hash = models.CharField(max_length=64)
+    status = models.CharField(max_length=20, choices=STATUS_CHOICES, default='pending')
+    expires_at = models.DateTimeField()
+    accepted_at = models.DateTimeField(null=True, blank=True)
+    accepted_user = models.ForeignKey(
+        CustomUser, null=True, blank=True, on_delete=models.SET_NULL, related_name='accepted_tenant_invitations'
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=['unit', 'email'],
+                condition=models.Q(status='pending'),
+                name='property_tenantinvitation_unit_email_pending_uniq',
+            ),
+        ]
+
+    def __str__(self):
+        return f"TenantInvitation({self.email} → {self.unit})"

--- a/property/serializers.py
+++ b/property/serializers.py
@@ -1,5 +1,17 @@
 from rest_framework import serializers
-from .models import Property, Unit, PropertyImage, Lease, PropertyAgent, TenantApplication, LeaseDocument, PropertyReview, TenantReview, SavedSearch
+from .models import (
+    Property,
+    Unit,
+    PropertyImage,
+    Lease,
+    PropertyAgent,
+    TenantApplication,
+    LeaseDocument,
+    PropertyReview,
+    TenantReview,
+    SavedSearch,
+    TenantInvitation,
+)
 
 
 class PropertySerializer(serializers.ModelSerializer):
@@ -91,3 +103,47 @@ class SavedSearchSerializer(serializers.ModelSerializer):
         model = SavedSearch
         fields = ['id', 'name', 'filters', 'notify_on_match', 'created_at', 'updated_at']
         read_only_fields = ['id', 'created_at', 'updated_at']
+
+
+class TenantInvitationCreateSerializer(serializers.Serializer):
+    email = serializers.EmailField()
+    phone = serializers.CharField(required=False, allow_blank=True, default='')
+    first_name = serializers.CharField(required=False, allow_blank=True, default='')
+    last_name = serializers.CharField(required=False, allow_blank=True, default='')
+    start_date = serializers.DateField()
+    end_date = serializers.DateField(required=False, allow_null=True)
+    rent_amount = serializers.DecimalField(max_digits=10, decimal_places=2)
+
+
+class TenantInvitationSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = TenantInvitation
+        fields = [
+            'id',
+            'unit',
+            'email',
+            'phone',
+            'first_name',
+            'last_name',
+            'start_date',
+            'end_date',
+            'rent_amount',
+            'invited_by',
+            'status',
+            'expires_at',
+            'accepted_at',
+            'accepted_user',
+            'created_at',
+        ]
+        read_only_fields = fields
+
+
+class TenantInvitationAcceptSerializer(serializers.Serializer):
+    token = serializers.CharField()
+    password = serializers.CharField(write_only=True, min_length=8)
+    first_name = serializers.CharField(required=False, allow_blank=True, default='')
+    last_name = serializers.CharField(required=False, allow_blank=True, default='')
+    phone = serializers.CharField(required=False, allow_blank=True, default='')
+    national_id = serializers.CharField(required=False, allow_blank=True, default='')
+    emergency_contact_name = serializers.CharField(required=False, allow_blank=True, default='')
+    emergency_contact_phone = serializers.CharField(required=False, allow_blank=True, default='')

--- a/property/tenant_invite.py
+++ b/property/tenant_invite.py
@@ -1,0 +1,49 @@
+import hashlib
+import secrets
+from django.conf import settings
+from django.core.mail import send_mail
+
+
+def hash_invite_token(raw_token: str) -> str:
+    return hashlib.sha256(raw_token.encode('utf-8')).hexdigest()
+
+
+def new_invite_token() -> str:
+    return secrets.token_urlsafe(32)
+
+
+def send_tenant_invitation_email(to_email: str, raw_token: str, property_name: str, unit_name: str) -> None:
+    base = getattr(
+        settings,
+        'TENANT_INVITE_REDIRECT_BASE_URL',
+        'http://localhost:8000/tenant-invite/',
+    ).rstrip('/')
+    invite_url = f"{base}?token={raw_token}"
+    subject = 'Complete your Tree House tenant account'
+    message = (
+        f"You have been invited to rent {unit_name} at {property_name}.\n\n"
+        f"Complete your profile and set your password here:\n{invite_url}\n\n"
+        f"If you did not expect this email, you can ignore it."
+    )
+    send_mail(
+        subject=subject,
+        message=message,
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        recipient_list=[to_email],
+        fail_silently=True,
+    )
+
+
+def send_existing_tenant_lease_email(to_email: str, property_name: str, unit_name: str) -> None:
+    subject = 'New lease on Tree House'
+    message = (
+        f"A lease has been created for you for {unit_name} at {property_name}.\n\n"
+        f"Log in to your Tree House account to view details."
+    )
+    send_mail(
+        subject=subject,
+        message=message,
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        recipient_list=[to_email],
+        fail_silently=True,
+    )

--- a/property/tests.py
+++ b/property/tests.py
@@ -1,12 +1,14 @@
 from datetime import date, timedelta
 
 from django.urls import reverse
+from django.utils import timezone
 from rest_framework.test import APITestCase
 from rest_framework.authtoken.models import Token
 from rest_framework import status
 from django.contrib.auth import get_user_model
 from authentication.models import Role
-from .models import Property, Unit, PropertyAgent, Lease, TenantApplication, LeaseDocument, PropertyReview, TenantReview
+from .models import Property, Unit, PropertyAgent, Lease, TenantApplication, LeaseDocument, PropertyReview, TenantReview, TenantInvitation
+from .tenant_invite import hash_invite_token
 
 User = get_user_model()
 
@@ -914,3 +916,214 @@ class SavedSearchTests(APITestCase):
             format='json',
         )
         self.assertFalse(Notification.objects.filter(user=self.tenant, notification_type='new_listing').exists())
+
+
+class TenantInvitationTests(APITestCase):
+    def setUp(self):
+        self.landlord, self.landlord_token = make_user('inv_ll', 'Landlord')
+        self.landlord.email = 'landlord_inv@example.com'
+        self.landlord.save()
+        self.agent, self.agent_token = make_user('inv_ag', 'Agent')
+        self.tenant, self.tenant_token = make_user('inv_tn', 'Tenant')
+        self.tenant.email = 'existing_tenant@example.com'
+        self.tenant.save()
+        self.other, self.other_token = make_user('inv_oth', 'Landlord')
+        self.other.email = 'other_ll@example.com'
+        self.other.save()
+
+        self.property = Property.objects.create(
+            name='Inv Prop',
+            property_type='apartment',
+            owner=self.landlord,
+            created_by=self.landlord,
+        )
+        self.unit = Unit.objects.create(
+            property=self.property,
+            name='U1',
+            price='30000',
+            created_by=self.landlord,
+        )
+
+    def auth(self, token):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {token.key}')
+
+    def invite_payload(self, email='brandnew@example.com'):
+        return {
+            'email': email,
+            'start_date': str(date.today()),
+            'rent_amount': '25000.00',
+            'first_name': 'New',
+            'last_name': 'Person',
+        }
+
+    def test_landlord_create_invite_201_and_hashes_token(self):
+        self.auth(self.landlord_token)
+        r = self.client.post(
+            reverse('unit-tenant-invitation-list', args=[self.unit.id]),
+            self.invite_payload(),
+            format='json',
+        )
+        self.assertEqual(r.status_code, status.HTTP_201_CREATED)
+        self.assertIn('invite_token', r.data)
+        inv = TenantInvitation.objects.get(pk=r.data['id'])
+        self.assertEqual(inv.token_hash, hash_invite_token(r.data['invite_token']))
+        self.assertEqual(inv.status, 'pending')
+
+    def test_list_invitations(self):
+        self.auth(self.landlord_token)
+        self.client.post(
+            reverse('unit-tenant-invitation-list', args=[self.unit.id]),
+            self.invite_payload(),
+            format='json',
+        )
+        r = self.client.get(reverse('unit-tenant-invitation-list', args=[self.unit.id]))
+        self.assertEqual(r.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(r.data), 1)
+
+    def test_existing_tenant_email_creates_lease_without_invite_row(self):
+        self.auth(self.landlord_token)
+        r = self.client.post(
+            reverse('unit-tenant-invitation-list', args=[self.unit.id]),
+            self.invite_payload(email='existing_tenant@example.com'),
+            format='json',
+        )
+        self.assertEqual(r.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(r.data.get('lease_created'))
+        self.assertFalse(TenantInvitation.objects.filter(email__iexact='existing_tenant@example.com').exists())
+        self.unit.refresh_from_db()
+        self.assertTrue(self.unit.is_occupied)
+
+    def test_non_tenant_email_rejected(self):
+        self.auth(self.landlord_token)
+        r = self.client.post(
+            reverse('unit-tenant-invitation-list', args=[self.unit.id]),
+            self.invite_payload(email='landlord_inv@example.com'),
+            format='json',
+        )
+        self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_agent_assigned_can_create_invite(self):
+        PropertyAgent.objects.create(property=self.property, agent=self.agent, appointed_by=self.landlord)
+        self.auth(self.agent_token)
+        r = self.client.post(
+            reverse('unit-tenant-invitation-list', args=[self.unit.id]),
+            self.invite_payload(email='agent_invited@example.com'),
+            format='json',
+        )
+        self.assertEqual(r.status_code, status.HTTP_201_CREATED)
+
+    def test_unassigned_agent_403(self):
+        self.auth(self.agent_token)
+        r = self.client.post(
+            reverse('unit-tenant-invitation-list', args=[self.unit.id]),
+            self.invite_payload(),
+            format='json',
+        )
+        self.assertEqual(r.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_tenant_cannot_invite(self):
+        self.auth(self.tenant_token)
+        r = self.client.post(
+            reverse('unit-tenant-invitation-list', args=[self.unit.id]),
+            self.invite_payload(),
+            format='json',
+        )
+        self.assertEqual(r.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_other_landlord_cannot_invite(self):
+        self.auth(self.other_token)
+        r = self.client.post(
+            reverse('unit-tenant-invitation-list', args=[self.unit.id]),
+            self.invite_payload(),
+            format='json',
+        )
+        self.assertEqual(r.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_duplicate_pending_invite_400(self):
+        self.auth(self.landlord_token)
+        url = reverse('unit-tenant-invitation-list', args=[self.unit.id])
+        p = self.invite_payload(email='dup@example.com')
+        self.assertEqual(self.client.post(url, p, format='json').status_code, status.HTTP_201_CREATED)
+        r2 = self.client.post(url, p, format='json')
+        self.assertEqual(r2.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_accept_happy_path(self):
+        self.auth(self.landlord_token)
+        r = self.client.post(
+            reverse('unit-tenant-invitation-list', args=[self.unit.id]),
+            self.invite_payload(email='accept_me@example.com'),
+            format='json',
+        )
+        token = r.data['invite_token']
+        self.client.credentials()
+        acc = self.client.post(
+            reverse('tenant-invite-accept'),
+            {
+                'token': token,
+                'password': 'TestPass!12345',
+                'national_id': 'N1',
+            },
+            format='json',
+        )
+        self.assertEqual(acc.status_code, status.HTTP_201_CREATED, acc.data)
+        self.assertIn('key', acc.data)
+        u = User.objects.get(email='accept_me@example.com')
+        self.assertTrue(u.check_password('TestPass!12345'))
+        inv = TenantInvitation.objects.get(email__iexact='accept_me@example.com')
+        self.assertEqual(inv.status, 'accepted')
+        self.assertEqual(inv.accepted_user, u)
+        self.assertTrue(Lease.objects.filter(unit=self.unit, tenant=u).exists())
+
+    def test_accept_invalid_token(self):
+        self.client.credentials()
+        r = self.client.post(
+            reverse('tenant-invite-accept'),
+            {'token': 'not-a-real-token', 'password': 'TestPass!12345'},
+            format='json',
+        )
+        self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_accept_expired_invitation(self):
+        self.auth(self.landlord_token)
+        r = self.client.post(
+            reverse('unit-tenant-invitation-list', args=[self.unit.id]),
+            self.invite_payload(email='expired@example.com'),
+            format='json',
+        )
+        inv = TenantInvitation.objects.get(pk=r.data['id'])
+        inv.expires_at = timezone.now() - timedelta(days=1)
+        inv.save(update_fields=['expires_at'])
+        self.client.credentials()
+        r2 = self.client.post(
+            reverse('tenant-invite-accept'),
+            {'token': r.data['invite_token'], 'password': 'TestPass!12345'},
+            format='json',
+        )
+        self.assertEqual(r2.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_occupied_unit_cannot_invite(self):
+        self.unit.is_occupied = True
+        self.unit.save()
+        self.auth(self.landlord_token)
+        r = self.client.post(
+            reverse('unit-tenant-invitation-list', args=[self.unit.id]),
+            self.invite_payload(email='occ@example.com'),
+            format='json',
+        )
+        self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_resend_refreshes_token(self):
+        self.auth(self.landlord_token)
+        r1 = self.client.post(
+            reverse('unit-tenant-invitation-list', args=[self.unit.id]),
+            self.invite_payload(email='resend@example.com'),
+            format='json',
+        )
+        inv_id = r1.data['id']
+        old_hash = TenantInvitation.objects.get(pk=inv_id).token_hash
+        r2 = self.client.post(reverse('tenant-invitation-resend', args=[inv_id]), {}, format='json')
+        self.assertEqual(r2.status_code, status.HTTP_200_OK)
+        self.assertIn('invite_token', r2.data)
+        inv = TenantInvitation.objects.get(pk=inv_id)
+        self.assertNotEqual(inv.token_hash, old_hash)
+        self.assertEqual(inv.token_hash, hash_invite_token(r2.data['invite_token']))

--- a/property/urls.py
+++ b/property/urls.py
@@ -11,6 +11,8 @@ urlpatterns = [
     path('units/<int:unit_id>/images/', views.unit_image_list_create, name='unit-image-list-create'),
     path('units/<int:unit_id>/images/<int:image_id>/', views.unit_image_detail, name='unit-image-detail'),
     path('units/<int:unit_id>/lease/', views.lease_list_create, name='lease-list-create'),
+    path('units/<int:unit_id>/tenant-invitations/', views.tenant_invitation_list_create, name='unit-tenant-invitation-list'),
+    path('tenant-invitations/<int:pk>/resend/', views.tenant_invitation_resend, name='tenant-invitation-resend'),
     path('units/public/', views.public_units, name='public-units'),
     # Tenant applications
     path('applications/', views.application_list_create, name='application-list'),

--- a/property/views.py
+++ b/property/views.py
@@ -1,7 +1,9 @@
 import math
 from datetime import date, timedelta
 from decimal import Decimal
-from django.db import IntegrityError
+from django.db import IntegrityError, transaction
+from django.contrib.auth.password_validation import validate_password
+from django.core.exceptions import ValidationError as DjangoValidationError
 
 from django.utils import timezone
 from rest_framework.decorators import api_view, permission_classes
@@ -9,13 +11,36 @@ from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.response import Response
 from rest_framework import status
 from drf_spectacular.utils import extend_schema, OpenApiExample
-from .models import Property, Unit, PropertyImage, Lease, PropertyAgent, TenantApplication, LeaseDocument, PropertyReview, TenantReview, SavedSearch
+from .models import (
+    Property,
+    Unit,
+    PropertyImage,
+    Lease,
+    PropertyAgent,
+    TenantApplication,
+    LeaseDocument,
+    PropertyReview,
+    TenantReview,
+    SavedSearch,
+    TenantInvitation,
+)
 from .serializers import (
     PropertySerializer, UnitSerializer, PropertyImageSerializer,
     LeaseSerializer, PropertyAgentSerializer, TenantApplicationSerializer,
     LeaseDocumentSerializer, PropertyReviewSerializer, TenantReviewSerializer,
     SavedSearchSerializer,
+    TenantInvitationSerializer,
+    TenantInvitationCreateSerializer,
+    TenantInvitationAcceptSerializer,
 )
+from .tenant_invite import (
+    hash_invite_token,
+    new_invite_token,
+    send_tenant_invitation_email,
+    send_existing_tenant_lease_email,
+)
+from authentication.models import Role, TenantProfile, CustomUser
+from rest_framework.authtoken.models import Token
 
 
 def is_landlord(user):
@@ -1113,3 +1138,298 @@ def saved_search_detail(request, pk):
 
     search.delete()
     return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+# ── Tenant invitations (landlord/agent → new tenant onboarding) ─────────────
+
+
+def _can_manage_unit_invite(user, unit):
+    return is_admin(user) or unit.property.owner == user or is_agent_for(user, unit.property)
+
+
+def _unit_lease_block_reason(unit):
+    if unit.is_occupied:
+        return 'Unit is already occupied.'
+    if Lease.objects.filter(unit=unit).exists():
+        return 'This unit already has a lease.'
+    return None
+
+
+@extend_schema(methods=['GET'], summary="List tenant invitations for a unit")
+@extend_schema(
+    methods=['POST'],
+    summary="Invite a tenant by email (or create lease if tenant already exists)",
+    examples=[
+        OpenApiExample(
+            "Invite new tenant",
+            request_only=True,
+            value={
+                "email": "newtenant@example.com",
+                "phone": "+254712345678",
+                "first_name": "Jane",
+                "last_name": "Doe",
+                "start_date": "2026-05-01",
+                "end_date": "2027-04-30",
+                "rent_amount": "35000.00",
+            },
+        ),
+    ],
+)
+@api_view(['GET', 'POST'])
+@permission_classes([IsAuthenticated])
+def tenant_invitation_list_create(request, unit_id):
+    try:
+        unit = Unit.objects.select_related('property').get(pk=unit_id)
+    except Unit.DoesNotExist:
+        return Response({'detail': 'Unit not found.'}, status=status.HTTP_404_NOT_FOUND)
+
+    if not _can_manage_unit_invite(request.user, unit):
+        return Response({'detail': 'Permission denied.'}, status=status.HTTP_403_FORBIDDEN)
+
+    if request.method == 'GET':
+        qs = TenantInvitation.objects.filter(unit=unit).select_related('invited_by', 'accepted_user')
+        return Response(TenantInvitationSerializer(qs, many=True).data)
+
+    ser = TenantInvitationCreateSerializer(data=request.data)
+    if not ser.is_valid():
+        return Response(ser.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    block = _unit_lease_block_reason(unit)
+    if block:
+        return Response({'detail': block}, status=status.HTTP_400_BAD_REQUEST)
+
+    email = ser.validated_data['email'].strip().lower()
+    start_date = ser.validated_data['start_date']
+    end_date = ser.validated_data.get('end_date')
+    rent_amount = ser.validated_data['rent_amount']
+
+    existing = CustomUser.objects.filter(email__iexact=email).select_related('role').first()
+    if existing:
+        if not existing.role or existing.role.name != Role.TENANT:
+            return Response(
+                {'detail': 'This email belongs to an account that is not a tenant.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        try:
+            Lease.objects.create(
+                unit=unit,
+                tenant=existing,
+                start_date=start_date,
+                end_date=end_date,
+                rent_amount=rent_amount,
+            )
+            unit.is_occupied = True
+            unit.save()
+        except IntegrityError:
+            return Response({'detail': 'Could not create lease.'}, status=status.HTTP_400_BAD_REQUEST)
+
+        from notifications.utils import create_notification
+
+        create_notification(
+            existing,
+            'lease',
+            'New lease',
+            f'You have a new lease for {unit.name} at {unit.property.name}.',
+            action_url='',
+        )
+        send_existing_tenant_lease_email(existing.email, unit.property.name, unit.name)
+        lease = Lease.objects.get(unit=unit)
+        return Response(
+            {
+                'lease_created': True,
+                'lease': LeaseSerializer(lease).data,
+            },
+            status=status.HTTP_201_CREATED,
+        )
+
+    raw_token = new_invite_token()
+    token_hash = hash_invite_token(raw_token)
+    expires_at = timezone.now() + timedelta(days=14)
+
+    try:
+        inv = TenantInvitation.objects.create(
+            unit=unit,
+            email=email,
+            phone=ser.validated_data.get('phone') or '',
+            first_name=ser.validated_data.get('first_name') or '',
+            last_name=ser.validated_data.get('last_name') or '',
+            start_date=start_date,
+            end_date=end_date,
+            rent_amount=rent_amount,
+            invited_by=request.user,
+            token_hash=token_hash,
+            status='pending',
+            expires_at=expires_at,
+        )
+    except IntegrityError:
+        return Response(
+            {'detail': 'A pending invitation already exists for this email on this unit.'},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    send_tenant_invitation_email(email, raw_token, unit.property.name, unit.name)
+    out = TenantInvitationSerializer(inv).data
+    out['invite_token'] = raw_token
+    return Response(out, status=status.HTTP_201_CREATED)
+
+
+@extend_schema(
+    methods=['POST'],
+    summary="Resend tenant invitation email (new token)",
+    examples=[OpenApiExample('Resend', request_only=True, value={})],
+)
+@api_view(['POST'])
+@permission_classes([IsAuthenticated])
+def tenant_invitation_resend(request, pk):
+    try:
+        inv = TenantInvitation.objects.select_related('unit__property').get(pk=pk)
+    except TenantInvitation.DoesNotExist:
+        return Response({'detail': 'Invitation not found.'}, status=status.HTTP_404_NOT_FOUND)
+
+    if not _can_manage_unit_invite(request.user, inv.unit):
+        return Response({'detail': 'Permission denied.'}, status=status.HTTP_403_FORBIDDEN)
+
+    if inv.status != 'pending':
+        return Response({'detail': 'Only pending invitations can be resent.'}, status=status.HTTP_400_BAD_REQUEST)
+
+    if timezone.now() > inv.expires_at:
+        inv.status = 'expired'
+        inv.save()
+        return Response({'detail': 'Invitation has expired. Create a new invitation.'}, status=status.HTTP_400_BAD_REQUEST)
+
+    block = _unit_lease_block_reason(inv.unit)
+    if block:
+        return Response({'detail': block}, status=status.HTTP_400_BAD_REQUEST)
+
+    raw_token = new_invite_token()
+    inv.token_hash = hash_invite_token(raw_token)
+    inv.expires_at = timezone.now() + timedelta(days=14)
+    inv.save(update_fields=['token_hash', 'expires_at'])
+
+    send_tenant_invitation_email(inv.email, raw_token, inv.unit.property.name, inv.unit.name)
+    out = TenantInvitationSerializer(inv).data
+    out['invite_token'] = raw_token
+    return Response(out, status=status.HTTP_200_OK)
+
+
+@extend_schema(
+    methods=['POST'],
+    summary="Accept tenant invitation — set password, profile, create lease",
+    examples=[
+        OpenApiExample(
+            'Accept invite',
+            request_only=True,
+            value={
+                'token': '<token-from-email>',
+                'password': 'StrongPass!123',
+                'first_name': 'Jane',
+                'last_name': 'Doe',
+                'phone': '+254712345678',
+                'national_id': 'ID123',
+                'emergency_contact_name': 'John Doe',
+                'emergency_contact_phone': '+254700000000',
+            },
+        ),
+    ],
+)
+@api_view(['POST'])
+@permission_classes([AllowAny])
+def tenant_invitation_accept(request):
+    ser = TenantInvitationAcceptSerializer(data=request.data)
+    if not ser.is_valid():
+        return Response(ser.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    raw_token = ser.validated_data['token']
+    token_hash = hash_invite_token(raw_token)
+    try:
+        inv = TenantInvitation.objects.select_related('unit__property').get(
+            token_hash=token_hash,
+            status='pending',
+        )
+    except TenantInvitation.DoesNotExist:
+        return Response({'detail': 'Invalid or expired invitation.'}, status=status.HTTP_400_BAD_REQUEST)
+
+    if timezone.now() > inv.expires_at:
+        inv.status = 'expired'
+        inv.save(update_fields=['status'])
+        return Response({'detail': 'This invitation has expired.'}, status=status.HTTP_400_BAD_REQUEST)
+
+    unit = inv.unit
+    block = _unit_lease_block_reason(unit)
+    if block:
+        return Response({'detail': block}, status=status.HTTP_400_BAD_REQUEST)
+
+    email = inv.email.strip().lower()
+    if CustomUser.objects.filter(email__iexact=email).exists():
+        return Response(
+            {'detail': 'An account with this email already exists. Log in instead.'},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    tenant_role = Role.objects.get(name=Role.TENANT)
+    username = email
+    if len(username) > 150:
+        username = username[:150]
+
+    user = CustomUser(
+        username=username,
+        email=email,
+        first_name=ser.validated_data.get('first_name') or inv.first_name or '',
+        last_name=ser.validated_data.get('last_name') or inv.last_name or '',
+        phone=ser.validated_data.get('phone') or inv.phone or '',
+        role=tenant_role,
+    )
+    pwd = ser.validated_data['password']
+    try:
+        validate_password(pwd, user)
+    except DjangoValidationError as e:
+        return Response({'detail': list(e.messages)}, status=status.HTTP_400_BAD_REQUEST)
+
+    user.set_password(pwd)
+
+    try:
+        with transaction.atomic():
+            user.save()
+            TenantProfile.objects.create(
+                user=user,
+                national_id=ser.validated_data.get('national_id') or '',
+                emergency_contact_name=ser.validated_data.get('emergency_contact_name') or '',
+                emergency_contact_phone=ser.validated_data.get('emergency_contact_phone') or '',
+            )
+            Lease.objects.create(
+                unit=unit,
+                tenant=user,
+                start_date=inv.start_date,
+                end_date=inv.end_date,
+                rent_amount=inv.rent_amount,
+            )
+            unit.is_occupied = True
+            unit.save(update_fields=['is_occupied'])
+            inv.status = 'accepted'
+            inv.accepted_at = timezone.now()
+            inv.accepted_user = user
+            inv.save(update_fields=['status', 'accepted_at', 'accepted_user'])
+            token, _ = Token.objects.get_or_create(user=user)
+    except IntegrityError:
+        return Response({'detail': 'Could not complete registration.'}, status=status.HTTP_400_BAD_REQUEST)
+
+    try:
+        from allauth.account.models import EmailAddress
+
+        EmailAddress.objects.update_or_create(
+            user=user,
+            email=email,
+            defaults={'verified': True, 'primary': True},
+        )
+    except Exception:
+        pass
+
+    from authentication.serializers import CustomUserDetailsSerializer
+
+    return Response(
+        {
+            'key': token.key,
+            'user': CustomUserDetailsSerializer(user).data,
+        },
+        status=status.HTTP_201_CREATED,
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ defusedxml==0.7.1
 dj-database-url==3.1.2
 dj-rest-auth==4.0.0
 Django==4.2.23
+django-anymail[mailgun]==11.1
 django-allauth==0.52.0
 djangorestframework==3.16.0
 dotenv==0.9.9

--- a/treeHouse/settings.py
+++ b/treeHouse/settings.py
@@ -174,6 +174,10 @@ DEFAULT_FROM_EMAIL = os.getenv('DEFAULT_FROM_EMAIL', 'noreply@treehouse.com')
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 EMAIL_CONFIRM_REDIRECT_BASE_URL = os.getenv("EMAIL_CONFIRM_REDIRECT_BASE_URL", "http://localhost:8000/email-confirm/")
 PASSWORD_RESET_CONFIRM_REDIRECT_BASE_URL = os.getenv("PASSWORD_RESET_CONFIRM_REDIRECT_BASE_URL", "http://localhost:8000/password-reset-confirm/")
+TENANT_INVITE_REDIRECT_BASE_URL = os.getenv(
+    "TENANT_INVITE_REDIRECT_BASE_URL",
+    "http://localhost:8000/tenant-invite/",
+)
 
 # Internationalization
 # https://docs.djangoproject.com/en/5.1/topics/i18n/

--- a/treeHouse/settings.py
+++ b/treeHouse/settings.py
@@ -61,6 +61,8 @@ INSTALLED_APPS = [
 
     'corsheaders',
 
+    'anymail',
+
     'billing',
     'maintenance',
     'notifications',
@@ -171,7 +173,21 @@ STRIPE_WEBHOOK_SECRET = os.getenv('STRIPE_WEBHOOK_SECRET', 'whsec_placeholder')
 
 DEFAULT_FROM_EMAIL = os.getenv('DEFAULT_FROM_EMAIL', 'noreply@treehouse.com')
 
-EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+# Email: Mailgun (production) when MAILGUN_API_KEY + MAILGUN_SENDER_DOMAIN are set; else console (dev).
+MAILGUN_API_KEY = os.getenv('MAILGUN_API_KEY', '').strip()
+MAILGUN_SENDER_DOMAIN = os.getenv('MAILGUN_SENDER_DOMAIN', '').strip()
+if MAILGUN_API_KEY and MAILGUN_SENDER_DOMAIN:
+    EMAIL_BACKEND = 'anymail.backends.mailgun.EmailBackend'
+    ANYMAIL = {
+        'MAILGUN_API_KEY': MAILGUN_API_KEY,
+        'MAILGUN_SENDER_DOMAIN': MAILGUN_SENDER_DOMAIN,
+    }
+    # Use EU region if your Mailgun account is in the EU (https://documentation.mailgun.com/docs/mailgun/api-intro/#base-url)
+    if os.getenv('MAILGUN_EU', '').strip().lower() in ('1', 'true', 'yes'):
+        ANYMAIL['MAILGUN_API_URL'] = 'https://api.eu.mailgun.net/v3'
+else:
+    EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
 EMAIL_CONFIRM_REDIRECT_BASE_URL = os.getenv("EMAIL_CONFIRM_REDIRECT_BASE_URL", "http://localhost:8000/email-confirm/")
 PASSWORD_RESET_CONFIRM_REDIRECT_BASE_URL = os.getenv("PASSWORD_RESET_CONFIRM_REDIRECT_BASE_URL", "http://localhost:8000/password-reset-confirm/")
 TENANT_INVITE_REDIRECT_BASE_URL = os.getenv(


### PR DESCRIPTION
Landlord/agent can invite by email; existing tenants get lease directly. New tenants complete signup via POST /api/auth/tenant-invite/accept/. Adds TenantInvitation model, migration 0009, email helper, tests, and TENANT_INVITE_REDIRECT_BASE_URL. Updates API docs and CLAUDE.md.

Made-with: Cursor

## Summary by Sourcery

Add tenant invitation workflow allowing landlords and agents to invite prospective tenants by email and support invite acceptance without prior authentication.

New Features:
- Introduce TenantInvitation model to track unit-specific tenant invites with status and expiry.
- Expose unit-level endpoints to list, create, and resend tenant invitations, restricted to owners and assigned agents.
- Add unauthenticated endpoint for invitees to accept tenant invitations, creating tenant accounts, profiles, and leases with immediate login token.
- Automatically create leases and notify existing tenant users when invited by email instead of issuing an invitation.

Enhancements:
- Add email utilities and configuration for tenant invitation and existing-tenant lease notification flows, including redirect base URL setting in app configuration.

Documentation:
- Update API integration and setup docs and CLAUDE.md to document tenant invitation endpoints, auth-free accept flow, required environment variables, and model/migration additions.

Tests:
- Add API tests covering tenant invitation creation, permissions, duplicate handling, acceptance, expiry, resend behavior, and unit occupancy constraints.