### PR TITLE
chore: sync admin access rules and startup migration logging

### DIFF
--- a/authentication/migrations/0010_mark_admin_role_users_staff.py
+++ b/authentication/migrations/0010_mark_admin_role_users_staff.py
@@ -1,0 +1,28 @@
+from django.db import migrations
+
+
+def mark_admin_role_users_staff(apps, schema_editor):
+    CustomUser = apps.get_model('authentication', 'CustomUser')
+    Role = apps.get_model('authentication', 'Role')
+
+    admin_role = Role.objects.filter(name='Admin').first()
+    if not admin_role:
+        return
+
+    CustomUser.objects.filter(role=admin_role).update(is_staff=True)
+
+
+def noop_reverse(apps, schema_editor):
+    # Keep staff flags untouched on rollback to avoid accidental privilege drops.
+    return
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('authentication', '0009_seed_moving_company_role'),
+    ]
+
+    operations = [
+        migrations.RunPython(mark_admin_role_users_staff, reverse_code=noop_reverse),
+    ]

--- a/authentication/models.py
+++ b/authentication/models.py
@@ -21,6 +21,12 @@ class CustomUser(AbstractUser):
     phone = models.CharField(max_length=20, blank=True)
     role = models.ForeignKey(Role, on_delete=models.CASCADE, null=False)
 
+    def save(self, *args, **kwargs):
+        # Keep admin role and Django staff flag in sync for permission checks.
+        if self.role_id and Role.objects.filter(pk=self.role_id, name=Role.ADMIN).exists():
+            self.is_staff = True
+        super().save(*args, **kwargs)
+
 
 class TenantProfile(models.Model):
     user = models.OneToOneField(CustomUser, on_delete=models.CASCADE, related_name='tenant_profile')

--- a/authentication/serializers.py
+++ b/authentication/serializers.py
@@ -11,6 +11,11 @@ class CustomRegisterSerializer(RegisterSerializer):
 	first_name = serializers.CharField(required=False, allow_blank=True)
 	last_name = serializers.CharField(required=False, allow_blank=True)
 
+	def validate_role(self, value):
+		if value and value.name == Role.ADMIN:
+			raise serializers.ValidationError("Admin role cannot be self-assigned.")
+		return value
+
 	def get_cleaned_data(self):
 		data = super().get_cleaned_data()
 		data['phone'] = self.validated_data.get('phone', '')

--- a/authentication/tests.py
+++ b/authentication/tests.py
@@ -80,6 +80,7 @@ class RoleAPITests(APITestCase):
 class RegistrationTestCase(APITestCase):
     def setUp(self):
         self.role, _ = Role.objects.get_or_create(name="Tenant", defaults={"description": "Test role"})
+        self.admin_role, _ = Role.objects.get_or_create(name=Role.ADMIN, defaults={"description": "Administrator role"})
 
     # Python 3.14 broke super().__copy__() in Django 4.2's BaseContext, which the test
     # client triggers whenever allauth renders a template (email confirm or login message).
@@ -106,6 +107,36 @@ class RegistrationTestCase(APITestCase):
         self.assertEqual(user.role, self.role)
         self.assertEqual(user.first_name, "Test")
         self.assertEqual(user.last_name, "User")
+
+    @override_settings(ACCOUNT_EMAIL_VERIFICATION='none')
+    @patch('allauth.account.adapter.DefaultAccountAdapter.add_message')
+    def test_register_rejects_admin_role(self, _mock_msg):
+        url = reverse('rest_register')
+        data = {
+            "first_name": "Admin",
+            "last_name": "User",
+            "username": "badadmin",
+            "email": "badadmin@example.com",
+            "password1": "StrongPass!123",
+            "password2": "StrongPass!123",
+            "role": self.admin_role.id,
+        }
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('role', response.data)
+
+
+class AdminRoleStaffSyncTests(APITestCase):
+    def test_admin_role_forces_staff_flag(self):
+        admin_role, _ = Role.objects.get_or_create(name=Role.ADMIN, defaults={"description": "Administrator role"})
+        user = User.objects.create_user(
+            username="adminsync",
+            password="testpass",
+            role=admin_role,
+            is_staff=False,
+        )
+        user.refresh_from_db()
+        self.assertTrue(user.is_staff)
 
 
 class TenantProfileAPITests(APITestCase):

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,8 +7,14 @@ until pg_isready -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER"; do
 done
 echo "Postgres is ready."
 
+echo "Pending migration plan:"
+python manage.py showmigrations --plan
+
 echo "Running migrations..."
 python manage.py migrate --noinput
+
+echo "Applied migration state:"
+python manage.py showmigrations
 
 echo "Starting server..."
 exec gunicorn treeHouse.wsgi:application \


### PR DESCRIPTION
Made-with: Cursor

## Summary by Sourcery

Enforce alignment between the Admin application role and Django staff permissions while improving visibility into database migrations at startup.

New Features:
- Prevent users from self-assigning the Admin role during registration.

Bug Fixes:
- Ensure users with the Admin role are automatically marked as Django staff for consistent permission checks.

Enhancements:
- Backfill existing Admin-role users to staff via a data migration without altering staff flags on rollback.
- Log planned and applied database migrations during container startup for easier operational debugging.

Tests:
- Add registration tests verifying Admin role cannot be selected via the public registration endpoint.
- Add tests confirming that assigning the Admin role to a user forces the staff flag to be set.