### PR TITLE
chore: serve admin static files in Docker startup

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,6 +16,9 @@ python manage.py migrate --noinput
 echo "Applied migration state:"
 python manage.py showmigrations
 
+echo "Collecting static files..."
+python manage.py collectstatic --noinput
+
 echo "Starting server..."
 exec gunicorn treeHouse.wsgi:application \
     --bind 0.0.0.0:8000 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ sqlparse==0.5.3
 typing_extensions==4.14.1
 tzdata==2025.2
 urllib3==2.5.0
+whitenoise==6.11.0

--- a/treeHouse/settings.py
+++ b/treeHouse/settings.py
@@ -79,6 +79,7 @@ SITE_ID = 1
 MIDDLEWARE = [
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -211,6 +212,8 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/5.1/howto/static-files/
 
 STATIC_URL = 'static/'
+STATIC_ROOT = BASE_DIR / 'staticfiles'
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 # Media files (User uploads)
 MEDIA_URL = 'media/'


### PR DESCRIPTION
Made-with: Cursor

## Summary by Sourcery

Configure Django to collect and serve static files during Docker startup using WhiteNoise.

New Features:
- Serve collected static files via WhiteNoise middleware in the Django app.

Enhancements:
- Run Django collectstatic as part of the Docker entrypoint to ensure static assets are available at startup.
- Configure STATIC_ROOT and static files storage for compressed manifest-based static asset handling.

Build:
- Add WhiteNoise dependency to the application requirements for static file serving.