### PR TITLE
fix(auth): default Admin role for createsuperuser

### DIFF
--- a/authentication/models.py
+++ b/authentication/models.py
@@ -1,4 +1,4 @@
-from django.contrib.auth.models import AbstractUser
+from django.contrib.auth.models import AbstractUser, BaseUserManager
 from django.db import models
 
 
@@ -17,9 +17,41 @@ class Role(models.Model):
         return self.name
 
 
+class CustomUserManager(BaseUserManager):
+    """Ensures create_superuser always gets a role (defaults to Admin)."""
+
+    def create_user(self, username, email=None, password=None, **extra_fields):
+        if not username:
+            raise ValueError('The given username must be set')
+        if extra_fields.get('role') is None:
+            raise ValueError('The given role must be set')
+        email = self.normalize_email(email)
+        user = self.model(username=username, email=email, **extra_fields)
+        user.set_password(password)
+        user.save(using=self._db)
+        return user
+
+    def create_superuser(self, username, email=None, password=None, **extra_fields):
+        extra_fields.setdefault('is_staff', True)
+        extra_fields.setdefault('is_superuser', True)
+        if extra_fields.get('is_staff') is not True:
+            raise ValueError('Superuser must have is_staff=True.')
+        if extra_fields.get('is_superuser') is not True:
+            raise ValueError('Superuser must have is_superuser=True.')
+        if extra_fields.get('role') is None:
+            role, _ = Role.objects.get_or_create(
+                name=Role.ADMIN,
+                defaults={'description': 'Platform administrator'},
+            )
+            extra_fields['role'] = role
+        return self.create_user(username, email, password, **extra_fields)
+
+
 class CustomUser(AbstractUser):
     phone = models.CharField(max_length=20, blank=True)
     role = models.ForeignKey(Role, on_delete=models.CASCADE, null=False)
+
+    objects = CustomUserManager()
 
     def save(self, *args, **kwargs):
         # Keep admin role and Django staff flag in sync for permission checks.

--- a/authentication/tests.py
+++ b/authentication/tests.py
@@ -139,6 +139,18 @@ class AdminRoleStaffSyncTests(APITestCase):
         self.assertTrue(user.is_staff)
 
 
+class CreateSuperuserTests(APITestCase):
+    def test_create_superuser_assigns_admin_role_when_omitted(self):
+        user = User.objects.create_superuser(
+            username='djangoadmin',
+            email='djangoadmin@example.com',
+            password='StrongPass!123',
+        )
+        self.assertTrue(user.is_superuser)
+        self.assertTrue(user.is_staff)
+        self.assertEqual(user.role.name, Role.ADMIN)
+
+
 class TenantProfileAPITests(APITestCase):
     def setUp(self):
         self.role, _ = Role.objects.get_or_create(name="Tenant", defaults={"description": "Tenant role"})


### PR DESCRIPTION
Made-with: Cursor

## Summary by Sourcery

Ensure superuser creation always assigns an Admin role by introducing a custom user manager and add tests to cover the new behavior.

New Features:
- Introduce a custom user manager for the CustomUser model to centralize user and superuser creation with role handling.

Bug Fixes:
- Automatically assign the Admin role to superusers created via createsuperuser when no role is specified to prevent invalid users without roles.

Tests:
- Add API test case verifying that create_superuser creates an Admin superuser with appropriate flags and role when the role is omitted.