### PR TITLE
Add POST /api/billing/invoices/ for manual invoice creation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,7 +227,7 @@ Seeded via data migrations. Roles are:
 | Method | URL | Who |
 |--------|-----|-----|
 | GET/POST | `/api/billing/config/<property_id>/` | Owner/Admin |
-| GET | `/api/billing/invoices/` | Admin=all, Landlord=own properties, Agent=assigned, Tenant=own |
+| GET/POST | `/api/billing/invoices/` | GET: Admin=all, Landlord=own properties, Agent=assigned, Tenant=own — POST: Admin / property owner / assigned agent (requires billing config on property; body: `lease`, `period_start`, `period_end`, `due_date`, optional `rent_amount`) |
 | GET | `/api/billing/invoices/<pk>/` | Owner/Agent/Tenant |
 | POST | `/api/billing/invoices/<pk>/pay/` | Tenant only |
 | GET | `/api/billing/invoices/<pk>/payments/` | Owner/Agent/Tenant |

--- a/billing/serializers.py
+++ b/billing/serializers.py
@@ -1,4 +1,8 @@
+from decimal import Decimal
+
 from rest_framework import serializers
+from property.models import Lease
+
 from .models import BillingConfig, Invoice, Payment, Receipt, ReminderLog, ChargeType, AdditionalIncome, Expense
 
 
@@ -27,6 +31,42 @@ class InvoiceSerializer(serializers.ModelSerializer):
 
     def get_amount_paid(self, obj):
         return str(obj.amount_paid())
+
+
+class InvoiceCreateSerializer(serializers.Serializer):
+    lease = serializers.PrimaryKeyRelatedField(
+        queryset=Lease.objects.select_related('unit__property'),
+    )
+    period_start = serializers.DateField()
+    period_end = serializers.DateField()
+    due_date = serializers.DateField()
+    rent_amount = serializers.DecimalField(
+        max_digits=10, decimal_places=2, required=False, min_value=Decimal('0.01'),
+    )
+
+    def validate(self, data):
+        lease = data['lease']
+        if not lease.is_active:
+            raise serializers.ValidationError({'lease': 'Lease must be active.'})
+
+        period_start = data['period_start']
+        period_end = data['period_end']
+        if period_start > period_end:
+            raise serializers.ValidationError({
+                'period_end': 'period_end must be on or after period_start.',
+            })
+
+        if period_end < lease.start_date or (
+            lease.end_date is not None and period_start > lease.end_date
+        ):
+            raise serializers.ValidationError({
+                'period_start': 'Billing period does not overlap the lease.',
+            })
+
+        if data.get('rent_amount') is None:
+            data['rent_amount'] = lease.rent_amount
+
+        return data
 
 
 class PaymentSerializer(serializers.ModelSerializer):

--- a/billing/tests.py
+++ b/billing/tests.py
@@ -1,3 +1,4 @@
+import calendar
 from datetime import date, timedelta
 from decimal import Decimal
 from unittest.mock import patch, MagicMock
@@ -163,6 +164,138 @@ class InvoiceTests(APITestCase):
         self.auth(self.other_token)
         response = self.client.get(reverse('invoice-detail', args=[self.invoice.id]))
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
+class InvoiceCreateTests(APITestCase):
+    def setUp(self):
+        self.landlord, self.landlord_token = make_user('landlord_ic', 'Landlord')
+        self.other_landlord, self.other_token = make_user('landlord_ic2', 'Landlord')
+        self.tenant, self.tenant_token = make_user('tenant_ic', 'Tenant')
+        self.agent, self.agent_token = make_user('agent_ic', 'Agent')
+        self.admin, self.admin_token = make_user('admin_ic', 'Admin', is_staff=True)
+
+        self.prop = make_property(self.landlord)
+        self.unit = make_unit(self.prop, self.landlord)
+        self.lease = make_lease(self.unit, self.tenant)
+        BillingConfig.objects.create(
+            property=self.prop,
+            rent_due_day=5,
+            grace_period_days=3,
+            late_fee_percentage='5.00',
+            updated_by=self.landlord,
+        )
+
+    def auth(self, token):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {token.key}')
+
+    def _next_month_period(self):
+        today = date.today()
+        if today.month == 12:
+            y, m = today.year + 1, 1
+        else:
+            y, m = today.year, today.month + 1
+        ps = date(y, m, 1)
+        pe = date(y, m, calendar.monthrange(y, m)[1])
+        return ps, pe
+
+    def _create_payload(self, lease_id=None, **overrides):
+        ps, pe = self._next_month_period()
+        payload = {
+            'lease': lease_id if lease_id is not None else self.lease.id,
+            'period_start': ps.isoformat(),
+            'period_end': pe.isoformat(),
+            'due_date': ps.isoformat(),
+        }
+        payload.update(overrides)
+        return payload
+
+    def test_landlord_can_create_invoice(self):
+        self.auth(self.landlord_token)
+        response = self.client.post(reverse('invoice-list'), self._create_payload())
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Decimal(response.data['rent_amount']), Decimal('45000'))
+        self.assertEqual(Decimal(response.data['late_fee_amount']), Decimal('0'))
+        self.assertEqual(Decimal(response.data['total_amount']), Decimal('45000'))
+        self.assertEqual(response.data['status'], 'pending')
+
+    def test_rent_amount_override(self):
+        self.auth(self.landlord_token)
+        response = self.client.post(
+            reverse('invoice-list'),
+            self._create_payload(rent_amount='40000.00'),
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Decimal(response.data['rent_amount']), Decimal('40000'))
+        self.assertEqual(Decimal(response.data['total_amount']), Decimal('40000'))
+
+    def test_admin_can_create_invoice(self):
+        self.auth(self.admin_token)
+        response = self.client.post(reverse('invoice-list'), self._create_payload())
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_assigned_agent_can_create_invoice(self):
+        PropertyAgent.objects.create(
+            property=self.prop, agent=self.agent, appointed_by=self.landlord
+        )
+        self.auth(self.agent_token)
+        response = self.client.post(reverse('invoice-list'), self._create_payload())
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_unassigned_agent_forbidden(self):
+        self.auth(self.agent_token)
+        response = self.client.post(reverse('invoice-list'), self._create_payload())
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_other_landlord_forbidden(self):
+        self.auth(self.other_token)
+        response = self.client.post(reverse('invoice-list'), self._create_payload())
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_tenant_forbidden(self):
+        self.auth(self.tenant_token)
+        response = self.client.post(reverse('invoice-list'), self._create_payload())
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_duplicate_lease_period_returns_400(self):
+        self.auth(self.landlord_token)
+        payload = self._create_payload()
+        r1 = self.client.post(reverse('invoice-list'), payload)
+        self.assertEqual(r1.status_code, status.HTTP_201_CREATED)
+        r2 = self.client.post(reverse('invoice-list'), payload)
+        self.assertEqual(r2.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_missing_billing_config_returns_400(self):
+        prop2 = make_property(self.landlord)
+        unit2 = make_unit(prop2, self.landlord)
+        lease2 = make_lease(unit2, self.tenant)
+        self.auth(self.landlord_token)
+        response = self.client.post(reverse('invoice-list'), self._create_payload(lease_id=lease2.id))
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_inactive_lease_returns_400(self):
+        self.lease.is_active = False
+        self.lease.save()
+        self.auth(self.landlord_token)
+        response = self.client.post(reverse('invoice-list'), self._create_payload())
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_period_outside_lease_returns_400(self):
+        end = date.today()
+        self.lease.end_date = end
+        self.lease.save()
+        self.auth(self.landlord_token)
+        future_start = end + timedelta(days=40)
+        future_end = future_start + timedelta(days=27)
+        response = self.client.post(
+            reverse('invoice-list'),
+            {
+                'lease': self.lease.id,
+                'period_start': future_start.isoformat(),
+                'period_end': future_end.isoformat(),
+                'due_date': future_start.isoformat(),
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
 class PaymentTests(APITestCase):

--- a/billing/views.py
+++ b/billing/views.py
@@ -18,7 +18,7 @@ from property.models import Property, Unit, Lease
 from property.views import is_admin, is_landlord, is_agent_for
 from .models import BillingConfig, Invoice, Payment, Receipt, ChargeType, AdditionalIncome, Expense
 from .serializers import (
-    BillingConfigSerializer, InvoiceSerializer,
+    BillingConfigSerializer, InvoiceSerializer, InvoiceCreateSerializer,
     PaymentSerializer, ReceiptSerializer,
     ChargeTypeSerializer, AdditionalIncomeSerializer, ExpenseSerializer,
 )
@@ -76,24 +76,80 @@ def billing_config(request, property_id):
 # ── Invoices ───────────────────────────────────────────────────────────────────
 
 @extend_schema(methods=['GET'], summary="List invoices")
-@api_view(['GET'])
+@extend_schema(
+    methods=['POST'],
+    summary="Create invoice manually",
+    examples=[
+        OpenApiExample(
+            "Create invoice",
+            request_only=True,
+            value={
+                'lease': 1,
+                'period_start': '2026-04-01',
+                'period_end': '2026-04-30',
+                'due_date': '2026-04-05',
+                'rent_amount': '45000.00',
+            },
+        ),
+    ],
+)
+@api_view(['GET', 'POST'])
 @permission_classes([IsAuthenticated])
 def invoice_list(request):
     user = request.user
-    if is_admin(user):
-        invoices = Invoice.objects.select_related('lease__unit__property').all()
-    elif is_landlord(user):
-        invoices = Invoice.objects.filter(lease__unit__property__owner=user)
-    elif hasattr(user, 'role') and user.role.name == 'Agent':
-        from property.models import PropertyAgent
-        assigned_ids = PropertyAgent.objects.filter(agent=user).values_list('property_id', flat=True)
-        invoices = Invoice.objects.filter(lease__unit__property_id__in=assigned_ids)
-    else:
-        # Tenant sees their own invoices
-        invoices = Invoice.objects.filter(lease__tenant=user)
 
-    serializer = InvoiceSerializer(invoices, many=True)
-    return Response(serializer.data)
+    if request.method == 'GET':
+        if is_admin(user):
+            invoices = Invoice.objects.select_related('lease__unit__property').all()
+        elif is_landlord(user):
+            invoices = Invoice.objects.filter(lease__unit__property__owner=user)
+        elif hasattr(user, 'role') and user.role.name == 'Agent':
+            from property.models import PropertyAgent
+            assigned_ids = PropertyAgent.objects.filter(agent=user).values_list('property_id', flat=True)
+            invoices = Invoice.objects.filter(lease__unit__property_id__in=assigned_ids)
+        else:
+            # Tenant sees their own invoices
+            invoices = Invoice.objects.filter(lease__tenant=user)
+
+        serializer = InvoiceSerializer(invoices, many=True)
+        return Response(serializer.data)
+
+    serializer = InvoiceCreateSerializer(data=request.data)
+    if not serializer.is_valid():
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    lease = serializer.validated_data['lease']
+    prop = lease.unit.property
+    can_create = is_admin(user) or prop.owner == user or is_agent_for(user, prop)
+    if not can_create:
+        return Response({'detail': 'Permission denied.'}, status=status.HTTP_403_FORBIDDEN)
+
+    try:
+        prop.billing_config
+    except BillingConfig.DoesNotExist:
+        return Response(
+            {'detail': 'No billing config set for this property.'},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    try:
+        invoice = Invoice.objects.create(
+            lease=lease,
+            period_start=serializer.validated_data['period_start'],
+            period_end=serializer.validated_data['period_end'],
+            due_date=serializer.validated_data['due_date'],
+            rent_amount=serializer.validated_data['rent_amount'],
+            late_fee_amount=Decimal('0'),
+            total_amount=serializer.validated_data['rent_amount'],
+            status='pending',
+        )
+    except IntegrityError:
+        return Response(
+            {'detail': 'An invoice for this lease and period_start already exists.'},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    return Response(InvoiceSerializer(invoice).data, status=status.HTTP_201_CREATED)
 
 
 @extend_schema(methods=['GET'], summary="Get invoice detail")

--- a/docs/api-integration.md
+++ b/docs/api-integration.md
@@ -48,6 +48,7 @@ Content-Type: `application/json`
 | **— BILLING —** | | | | | | | |
 | Configure billing | ✗ | ✓ | Own | ✗ | ✗ | ✗ | ✗ |
 | List / view invoices | ✗ | All | Own | Assigned | Own | ✗ | ✗ |
+| Create invoice (manual) | ✗ | ✓ | Own | Assigned | ✗ | ✗ | ✗ |
 | Pay invoice (Stripe) | ✗ | ✗ | ✗ | ✗ | Own | ✗ | ✗ |
 | View payments & receipts | ✗ | All | Own | Assigned | Own | ✗ | ✗ |
 | Manage charge types | ✗ | ✓ | Own | View only | ✗ | ✗ | ✗ |
@@ -665,11 +666,67 @@ Scoped by role:
     "rent_amount": "25000.00",
     "late_fee_amount": "0.00",
     "total_amount": "25000.00",
-    "status": "pending"
+    "status": "pending",
+    "amount_paid": "0",
+    "created_at": "2024-02-01T08:00:00Z"
   }
 ]
 ```
 Invoice status values: `pending`, `paid`, `partial`, `overdue`, `cancelled`
+
+---
+
+### Create invoice manually (Owner / Assigned Agent / Admin)
+`POST /api/billing/invoices/`
+
+Use this to issue a rent invoice outside the automatic `process_billing` schedule (e.g. backfill, proration, or an extra period). The property must already have billing configuration (`POST /api/billing/config/<property_id>/`). The lease must be **active**; the billing period must **overlap** the lease dates (`start_date` / optional `end_date`).
+
+**Who can call:** platform admin, the property owner, or an agent appointed to that property. Tenants and other roles get `403`.
+
+**Constraints:**
+- At most one invoice per `(lease, period_start)` — duplicate returns `400`.
+- Omitting `rent_amount` uses the lease’s `rent_amount`; you may override for prorations.
+- New invoices are created with `late_fee_amount = 0`, `status = pending`, `total_amount = rent_amount` (late fees are applied later by `process_billing` when overdue).
+
+```json
+// Request
+{
+  "lease": 2,
+  "period_start": "2024-03-01",
+  "period_end": "2024-03-31",
+  "due_date": "2024-03-06",
+  "rent_amount": "25000.00"
+}
+```
+
+`rent_amount` is optional.
+
+```json
+// Response 201 — same shape as GET list/detail (`amount_paid`, `created_at` included)
+{
+  "id": 15,
+  "lease": 2,
+  "period_start": "2024-03-01",
+  "period_end": "2024-03-31",
+  "due_date": "2024-03-06",
+  "rent_amount": "25000.00",
+  "late_fee_amount": "0.00",
+  "total_amount": "25000.00",
+  "status": "pending",
+  "amount_paid": "0",
+  "created_at": "2024-03-01T08:00:00Z"
+}
+```
+
+**Common errors:**
+
+| Situation | Status |
+|-----------|--------|
+| Not owner / assigned agent / admin | `403` |
+| No billing config on the property | `400` — `No billing config set for this property.` |
+| Duplicate `period_start` for that lease | `400` — `An invoice for this lease and period_start already exists.` |
+| Lease inactive or period outside lease dates | `400` — field errors from validation |
+| `period_end` before `period_start` | `400` |
 
 ---
 


### PR DESCRIPTION
Landlord, assigned agent, or admin can create invoices when billing config exists; docs and tests updated.

Made-with: Cursor

## Summary by Sourcery

Add support for manual invoice creation via POST on the invoices endpoint with appropriate validation, permissions, and documentation.

New Features:
- Allow admins, property owners, and assigned agents to manually create rent invoices via POST /api/billing/invoices/.
- Introduce a dedicated serializer for validating manual invoice creation payloads and defaulting rent amounts from the lease when omitted.

Enhancements:
- Extend invoice listing endpoint to handle both GET and POST while preserving existing listing behaviour by role.
- Enforce business rules on manual invoice creation, including active lease requirement, billing period overlap, uniqueness per (lease, period_start), and presence of billing configuration.

Documentation:
- Document the manual invoice creation endpoint, including payload, responses, constraints, and role-based access in the API integration guide.
- Update high-level API overview documentation to reflect POST support on /api/billing/invoices/.
- Clarify invoice list response fields in documentation to include amount_paid and created_at.

Tests:
- Add API tests covering successful manual invoice creation, permission checks by role, billing configuration requirements, duplicate protection, and lease/billing period validation.