### PR TITLE
Add POST /api/billing/invoices/<pk>/payments/ for manual rent recording

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,7 +230,7 @@ Seeded via data migrations. Roles are:
 | GET/POST | `/api/billing/invoices/` | GET: Admin=all, Landlord=own properties, Agent=assigned, Tenant=own — POST: Admin / property owner / assigned agent (requires billing config on property; body: `lease`, `period_start`, `period_end`, `due_date`, optional `rent_amount`) |
 | GET | `/api/billing/invoices/<pk>/` | Owner/Agent/Tenant |
 | POST | `/api/billing/invoices/<pk>/pay/` | Tenant only |
-| GET | `/api/billing/invoices/<pk>/payments/` | Owner/Agent/Tenant |
+| GET/POST | `/api/billing/invoices/<pk>/payments/` | GET: Owner/Agent/Tenant — POST: record manual payment (cash/bank); Owner/Assigned Agent/Admin only; body `amount`; creates completed `Payment` (`stripe_payment_intent_id` prefix `manual-`), receipt, updates invoice status |
 | GET | `/api/billing/receipts/` | Scoped by role |
 | GET | `/api/billing/receipts/<pk>/` | Owner/Agent/Tenant |
 | POST | `/api/billing/stripe/webhook/` | Stripe (no auth, CSRF exempt) |

--- a/billing/management/commands/process_billing.py
+++ b/billing/management/commands/process_billing.py
@@ -3,12 +3,10 @@ from datetime import date, timedelta
 from decimal import Decimal
 
 from django.core.management.base import BaseCommand
-from django.core.mail import send_mail
-from django.conf import settings
 from django.utils import timezone
 
 from property.models import Lease
-from billing.models import BillingConfig, Invoice, ReminderLog
+from billing.models import BillingConfig, Invoice, ReminderLog, PropertyBillingNotificationSettings
 
 
 class Command(BaseCommand):
@@ -34,13 +32,16 @@ class Command(BaseCommand):
                 self.stdout.write(f'  No billing config for property "{lease.unit.property.name}" — skipping')
                 continue
 
-            due_day = self._clamp_due_day(config.rent_due_day, today.year, today.month)
-            if today.day != due_day:
+            y, m = today.year, today.month
+            clamped_due = self._clamp_due_day(config.rent_due_day, y, m)
+            gen_day = max(1, clamped_due - config.invoice_lead_days)
+            if today.day != gen_day:
                 continue
 
             period_start = today.replace(day=1)
             period_end = today.replace(day=calendar.monthrange(today.year, today.month)[1])
-            due_date = today + timedelta(days=config.grace_period_days)
+            anchor = date(y, m, clamped_due)
+            due_date = anchor + timedelta(days=config.grace_period_days)
 
             _, created = Invoice.objects.get_or_create(
                 lease=lease,
@@ -73,11 +74,18 @@ class Command(BaseCommand):
             except BillingConfig.DoesNotExist:
                 continue
 
-            late_fee = (invoice.rent_amount * config.late_fee_percentage / Decimal('100')).quantize(Decimal('0.01'))
+            if config.late_fee_mode == BillingConfig.LATE_FEE_MODE_FIXED:
+                late_fee = (config.late_fee_fixed_amount or Decimal('0')).quantize(Decimal('0.01'))
+            else:
+                late_fee = (
+                    invoice.rent_amount * config.late_fee_percentage / Decimal('100')
+                ).quantize(Decimal('0.01'))
 
-            if config.late_fee_max_percentage:
-                max_fee = (invoice.rent_amount * config.late_fee_max_percentage / Decimal('100')).quantize(Decimal('0.01'))
-                late_fee = min(late_fee, max_fee)
+                if config.late_fee_max_percentage:
+                    max_fee = (
+                        invoice.rent_amount * config.late_fee_max_percentage / Decimal('100')
+                    ).quantize(Decimal('0.01'))
+                    late_fee = min(late_fee, max_fee)
 
             invoice.late_fee_amount = late_fee
             invoice.total_amount = invoice.rent_amount + late_fee
@@ -88,40 +96,70 @@ class Command(BaseCommand):
                 f'  Late fee applied: {invoice.lease.tenant.username} — Invoice {invoice.id} (+{late_fee})'
             ))
 
-    # ── Email Reminders ─────────────────────────────────────────────────────────
+    # ── Reminders ───────────────────────────────────────────────────────────────
 
     def _send_reminders(self, today):
         self._send_pre_due_reminders(today)
         self._send_due_date_reminders(today)
-        self._send_overdue_reminders()
+        self._send_overdue_reminders(today)
+
+    def _pre_due_offset_days(self, prop):
+        """Legacy: no settings row → 3. Row exists with null remind_before_due_days → disabled."""
+        try:
+            s = prop.billing_notification_settings
+        except PropertyBillingNotificationSettings.DoesNotExist:
+            return 3
+        if s.remind_before_due_days is None:
+            return None
+        return s.remind_before_due_days
+
+    def _overdue_reminder_delay_days(self, prop):
+        """Days after invoice due_date before sending overdue reminder. Null → 0."""
+        try:
+            s = prop.billing_notification_settings
+        except PropertyBillingNotificationSettings.DoesNotExist:
+            return 0
+        if s.remind_after_overdue_days is None:
+            return 0
+        return s.remind_after_overdue_days
 
     def _send_pre_due_reminders(self, today):
-        target_due = today + timedelta(days=3)
-        invoices = Invoice.objects.filter(
-            due_date=target_due,
-            status__in=['pending', 'partial'],
-        ).exclude(reminders__reminder_type='pre_due').select_related('lease__tenant')
+        from notifications.utils import create_notification
 
-        for invoice in invoices:
+        candidates = Invoice.objects.filter(
+            status__in=['pending', 'partial'],
+        ).exclude(reminders__reminder_type='pre_due').select_related(
+            'lease__tenant', 'lease__unit__property',
+        )
+
+        for invoice in candidates:
+            prop = invoice.lease.unit.property
+            n = self._pre_due_offset_days(prop)
+            if n is None:
+                continue
+            if invoice.due_date != today + timedelta(days=n):
+                continue
+
             tenant = invoice.lease.tenant
-            send_mail(
-                subject='Rent due in 3 days',
-                message=(
-                    f'Hi {tenant.first_name or tenant.username},\n\n'
-                    f'This is a reminder that your rent of KES {invoice.total_amount} '
-                    f'is due on {invoice.due_date}.\n\n'
-                    f'Invoice #{invoice.id} | Period: {invoice.period_start} – {invoice.period_end}\n\n'
-                    f'Please ensure payment is made on time to avoid late fees.\n\n'
-                    f'Tree House'
-                ),
-                from_email=settings.DEFAULT_FROM_EMAIL,
-                recipient_list=[tenant.email],
-                fail_silently=True,
+            title = f'Rent due in {n} day{"s" if n != 1 else ""}'
+            body = (
+                f'Hi {tenant.first_name or tenant.username},\n\n'
+                f'This is a reminder that your rent of KES {invoice.total_amount} '
+                f'is due on {invoice.due_date}.\n\n'
+                f'Invoice #{invoice.id} | Period: {invoice.period_start} – {invoice.period_end}\n\n'
+                f'Please ensure payment is made on time to avoid late fees.\n\n'
+                f'Tree House'
+            )
+            create_notification(
+                tenant, 'payment_reminder', title, body,
+                action_url='',
             )
             ReminderLog.objects.create(invoice=invoice, reminder_type='pre_due')
             self.stdout.write(f'  Pre-due reminder sent to {tenant.email}')
 
     def _send_due_date_reminders(self, today):
+        from notifications.utils import create_notification
+
         invoices = Invoice.objects.filter(
             due_date=today,
             status__in=['pending', 'partial'],
@@ -129,44 +167,46 @@ class Command(BaseCommand):
 
         for invoice in invoices:
             tenant = invoice.lease.tenant
-            send_mail(
-                subject='Rent is due today',
-                message=(
-                    f'Hi {tenant.first_name or tenant.username},\n\n'
-                    f'Your rent of KES {invoice.total_amount} is due today ({invoice.due_date}).\n\n'
-                    f'Invoice #{invoice.id} | Period: {invoice.period_start} – {invoice.period_end}\n\n'
-                    f'Please make payment today to avoid late fees.\n\n'
-                    f'Tree House'
-                ),
-                from_email=settings.DEFAULT_FROM_EMAIL,
-                recipient_list=[tenant.email],
-                fail_silently=True,
+            title = 'Rent is due today'
+            body = (
+                f'Hi {tenant.first_name or tenant.username},\n\n'
+                f'Your rent of KES {invoice.total_amount} is due today ({invoice.due_date}).\n\n'
+                f'Invoice #{invoice.id} | Period: {invoice.period_start} – {invoice.period_end}\n\n'
+                f'Please make payment today to avoid late fees.\n\n'
+                f'Tree House'
             )
+            create_notification(tenant, 'payment_reminder', title, body, action_url='')
             ReminderLog.objects.create(invoice=invoice, reminder_type='due_date')
             self.stdout.write(f'  Due-date reminder sent to {tenant.email}')
 
-    def _send_overdue_reminders(self):
+    def _send_overdue_reminders(self, today):
+        from notifications.utils import create_notification
+
         invoices = Invoice.objects.filter(
             status='overdue',
-        ).exclude(reminders__reminder_type='overdue').select_related('lease__tenant')
+        ).exclude(reminders__reminder_type='overdue').select_related(
+            'lease__tenant', 'lease__unit__property',
+        )
 
         for invoice in invoices:
+            prop = invoice.lease.unit.property
+            delay = self._overdue_reminder_delay_days(prop)
+            threshold = invoice.due_date + timedelta(days=delay)
+            if today < threshold:
+                continue
+
             tenant = invoice.lease.tenant
-            send_mail(
-                subject='Rent overdue — late fee applied',
-                message=(
-                    f'Hi {tenant.first_name or tenant.username},\n\n'
-                    f'Your rent for the period {invoice.period_start} – {invoice.period_end} is overdue.\n\n'
-                    f'Rent:      KES {invoice.rent_amount}\n'
-                    f'Late fee:  KES {invoice.late_fee_amount}\n'
-                    f'Total due: KES {invoice.total_amount}\n\n'
-                    f'Please make payment immediately to avoid further charges.\n\n'
-                    f'Tree House'
-                ),
-                from_email=settings.DEFAULT_FROM_EMAIL,
-                recipient_list=[tenant.email],
-                fail_silently=True,
+            title = 'Rent overdue — late fee applied'
+            body = (
+                f'Hi {tenant.first_name or tenant.username},\n\n'
+                f'Your rent for the period {invoice.period_start} – {invoice.period_end} is overdue.\n\n'
+                f'Rent:      KES {invoice.rent_amount}\n'
+                f'Late fee:  KES {invoice.late_fee_amount}\n'
+                f'Total due: KES {invoice.total_amount}\n\n'
+                f'Please make payment immediately to avoid further charges.\n\n'
+                f'Tree House'
             )
+            create_notification(tenant, 'payment_reminder', title, body, action_url='')
             ReminderLog.objects.create(invoice=invoice, reminder_type='overdue')
             self.stdout.write(self.style.ERROR(f'  Overdue reminder sent to {tenant.email}'))
 

--- a/billing/migrations/0003_billing_expansion.py
+++ b/billing/migrations/0003_billing_expansion.py
@@ -1,0 +1,121 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('billing', '0002_add_expense_chargetype_additionalincome'),
+        ('property', '0005_add_property_agent'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='billingconfig',
+            name='invoice_lead_days',
+            field=models.PositiveSmallIntegerField(default=0, help_text='Days before rent_due_day to generate invoice (0 = on due day).'),
+        ),
+        migrations.AddField(
+            model_name='billingconfig',
+            name='late_fee_mode',
+            field=models.CharField(
+                choices=[('percentage', 'Percentage'), ('fixed', 'Fixed')],
+                default='percentage',
+                max_length=20,
+            ),
+        ),
+        migrations.AddField(
+            model_name='billingconfig',
+            name='late_fee_fixed_amount',
+            field=models.DecimalField(blank=True, decimal_places=2, max_digits=10, null=True),
+        ),
+        migrations.AddField(
+            model_name='billingconfig',
+            name='mpesa_paybill',
+            field=models.CharField(blank=True, max_length=50),
+        ),
+        migrations.AddField(
+            model_name='billingconfig',
+            name='mpesa_account_label',
+            field=models.CharField(blank=True, max_length=100),
+        ),
+        migrations.AddField(
+            model_name='billingconfig',
+            name='bank_name',
+            field=models.CharField(blank=True, max_length=200),
+        ),
+        migrations.AddField(
+            model_name='billingconfig',
+            name='bank_account',
+            field=models.CharField(blank=True, max_length=100),
+        ),
+        migrations.AddField(
+            model_name='billingconfig',
+            name='payment_notes',
+            field=models.TextField(blank=True),
+        ),
+        migrations.AddField(
+            model_name='chargetype',
+            name='charge_kind',
+            field=models.CharField(
+                choices=[('fixed', 'Fixed'), ('variable', 'Variable'), ('per_unit', 'Per unit')],
+                default='variable',
+                max_length=20,
+            ),
+        ),
+        migrations.AddField(
+            model_name='chargetype',
+            name='default_amount',
+            field=models.DecimalField(blank=True, decimal_places=2, max_digits=10, null=True),
+        ),
+        migrations.AddField(
+            model_name='chargetype',
+            name='description',
+            field=models.TextField(blank=True),
+        ),
+        migrations.AddField(
+            model_name='chargetype',
+            name='display_order',
+            field=models.PositiveSmallIntegerField(default=0),
+        ),
+        migrations.AddField(
+            model_name='chargetype',
+            name='is_active',
+            field=models.BooleanField(default=True),
+        ),
+        migrations.CreateModel(
+            name='PropertyBillingNotificationSettings',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                (
+                    'remind_before_due_days',
+                    models.PositiveSmallIntegerField(
+                        blank=True,
+                        help_text='Days before due_date to send pre-due reminder; null disables. If no settings row exists, legacy default 3 applies.',
+                        null=True,
+                    ),
+                ),
+                (
+                    'remind_after_overdue_days',
+                    models.PositiveSmallIntegerField(
+                        blank=True,
+                        help_text='Days after due_date before sending overdue reminder; null/0 sends as soon as invoice is overdue.',
+                        null=True,
+                    ),
+                ),
+                ('send_receipt_on_payment', models.BooleanField(default=True)),
+                (
+                    'property',
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='billing_notification_settings',
+                        to='property.property',
+                    ),
+                ),
+            ],
+            options={
+                'verbose_name': 'Property billing notification settings',
+                'verbose_name_plural': 'Property billing notification settings',
+            },
+        ),
+    ]

--- a/billing/models.py
+++ b/billing/models.py
@@ -5,16 +5,64 @@ from property.models import Property, Unit, Lease
 
 
 class BillingConfig(models.Model):
+    LATE_FEE_MODE_PERCENTAGE = 'percentage'
+    LATE_FEE_MODE_FIXED = 'fixed'
+    LATE_FEE_MODE_CHOICES = [
+        (LATE_FEE_MODE_PERCENTAGE, 'Percentage'),
+        (LATE_FEE_MODE_FIXED, 'Fixed'),
+    ]
+
     property = models.OneToOneField(Property, on_delete=models.CASCADE, related_name='billing_config')
     rent_due_day = models.PositiveIntegerField(help_text="Day of month rent is due (1-28)")
     grace_period_days = models.PositiveIntegerField(default=0, help_text="Days after due date before late fee applies")
     late_fee_percentage = models.DecimalField(max_digits=5, decimal_places=2, help_text="Late fee as % of rent amount")
     late_fee_max_percentage = models.DecimalField(max_digits=5, decimal_places=2, null=True, blank=True, help_text="Cap on total late fees as % of rent")
+    invoice_lead_days = models.PositiveSmallIntegerField(
+        default=0,
+        help_text="Days before rent_due_day to generate invoice (0 = on due day).",
+    )
+    late_fee_mode = models.CharField(
+        max_length=20, choices=LATE_FEE_MODE_CHOICES, default=LATE_FEE_MODE_PERCENTAGE,
+    )
+    late_fee_fixed_amount = models.DecimalField(
+        max_digits=10, decimal_places=2, null=True, blank=True,
+    )
+    mpesa_paybill = models.CharField(max_length=50, blank=True)
+    mpesa_account_label = models.CharField(max_length=100, blank=True)
+    bank_name = models.CharField(max_length=200, blank=True)
+    bank_account = models.CharField(max_length=100, blank=True)
+    payment_notes = models.TextField(blank=True)
     updated_at = models.DateTimeField(auto_now=True)
     updated_by = models.ForeignKey(CustomUser, on_delete=models.SET_NULL, null=True, blank=True)
 
     def __str__(self):
         return f"BillingConfig for {self.property.name}"
+
+
+class PropertyBillingNotificationSettings(models.Model):
+    """Per-property billing email/in-app reminder behavior (optional row)."""
+
+    property = models.OneToOneField(
+        Property, on_delete=models.CASCADE, related_name='billing_notification_settings',
+    )
+    remind_before_due_days = models.PositiveSmallIntegerField(
+        null=True,
+        blank=True,
+        help_text="Days before due_date for pre-due reminder; null disables. If no settings row, legacy 3 applies.",
+    )
+    remind_after_overdue_days = models.PositiveSmallIntegerField(
+        null=True,
+        blank=True,
+        help_text="Days after due_date before overdue reminder; null treats as 0 (as soon as overdue).",
+    )
+    send_receipt_on_payment = models.BooleanField(default=True)
+
+    class Meta:
+        verbose_name = 'Property billing notification settings'
+        verbose_name_plural = 'Property billing notification settings'
+
+    def __str__(self):
+        return f"BillingNotificationSettings({self.property.name})"
 
 
 class Invoice(models.Model):
@@ -104,8 +152,25 @@ class ReminderLog(models.Model):
 
 class ChargeType(models.Model):
     """Landlord-defined income categories per property (water, electricity, service charge, etc.)."""
+
+    KIND_FIXED = 'fixed'
+    KIND_VARIABLE = 'variable'
+    KIND_PER_UNIT = 'per_unit'
+    CHARGE_KIND_CHOICES = [
+        (KIND_FIXED, 'Fixed'),
+        (KIND_VARIABLE, 'Variable'),
+        (KIND_PER_UNIT, 'Per unit'),
+    ]
+
     property = models.ForeignKey(Property, on_delete=models.CASCADE, related_name='charge_types')
     name = models.CharField(max_length=100)
+    charge_kind = models.CharField(
+        max_length=20, choices=CHARGE_KIND_CHOICES, default=KIND_VARIABLE,
+    )
+    default_amount = models.DecimalField(max_digits=10, decimal_places=2, null=True, blank=True)
+    description = models.TextField(blank=True)
+    display_order = models.PositiveSmallIntegerField(default=0)
+    is_active = models.BooleanField(default=True)
     created_by = models.ForeignKey(CustomUser, on_delete=models.CASCADE, related_name='created_charge_types')
     created_at = models.DateTimeField(auto_now_add=True)
 

--- a/billing/serializers.py
+++ b/billing/serializers.py
@@ -3,20 +3,103 @@ from decimal import Decimal
 from rest_framework import serializers
 from property.models import Lease
 
-from .models import BillingConfig, Invoice, Payment, Receipt, ReminderLog, ChargeType, AdditionalIncome, Expense
+from .models import (
+    BillingConfig,
+    Invoice,
+    Payment,
+    Receipt,
+    ReminderLog,
+    ChargeType,
+    AdditionalIncome,
+    Expense,
+    PropertyBillingNotificationSettings,
+)
+
+
+class PropertyBillingNotificationSettingsSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = PropertyBillingNotificationSettings
+        fields = [
+            'remind_before_due_days',
+            'remind_after_overdue_days',
+            'send_receipt_on_payment',
+        ]
 
 
 class BillingConfigSerializer(serializers.ModelSerializer):
+    notification_settings = PropertyBillingNotificationSettingsSerializer(
+        required=False, write_only=True,
+    )
+
     class Meta:
         model = BillingConfig
-        fields = ['id', 'property', 'rent_due_day', 'grace_period_days',
-                  'late_fee_percentage', 'late_fee_max_percentage', 'updated_at', 'updated_by']
+        fields = [
+            'id', 'property', 'rent_due_day', 'grace_period_days',
+            'late_fee_percentage', 'late_fee_max_percentage',
+            'invoice_lead_days', 'late_fee_mode', 'late_fee_fixed_amount',
+            'mpesa_paybill', 'mpesa_account_label', 'bank_name', 'bank_account', 'payment_notes',
+            'notification_settings',
+            'updated_at', 'updated_by',
+        ]
         read_only_fields = ['property', 'updated_at', 'updated_by']
 
     def validate_rent_due_day(self, value):
         if not (1 <= value <= 28):
             raise serializers.ValidationError("rent_due_day must be between 1 and 28.")
         return value
+
+    def validate_invoice_lead_days(self, value):
+        if value > 27:
+            raise serializers.ValidationError("invoice_lead_days must be at most 27.")
+        return value
+
+    def validate(self, attrs):
+        instance = self.instance
+        mode = attrs.get('late_fee_mode', getattr(instance, 'late_fee_mode', None) if instance else BillingConfig.LATE_FEE_MODE_PERCENTAGE)
+        if mode is None:
+            mode = BillingConfig.LATE_FEE_MODE_PERCENTAGE
+
+        fixed = attrs.get('late_fee_fixed_amount', getattr(instance, 'late_fee_fixed_amount', None) if instance else None)
+
+        if mode == BillingConfig.LATE_FEE_MODE_FIXED:
+            if fixed is None or fixed == '':
+                raise serializers.ValidationError({
+                    'late_fee_fixed_amount': 'This field is required when late_fee_mode is fixed.',
+                })
+        elif mode == BillingConfig.LATE_FEE_MODE_PERCENTAGE:
+            attrs['late_fee_fixed_amount'] = None
+
+        return attrs
+
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        data['configured'] = True
+        try:
+            ns = instance.property.billing_notification_settings
+            data['notification_settings'] = PropertyBillingNotificationSettingsSerializer(ns).data
+        except PropertyBillingNotificationSettings.DoesNotExist:
+            data['notification_settings'] = None
+        return data
+
+    def create(self, validated_data):
+        notification_data = validated_data.pop('notification_settings', None)
+        config = super().create(validated_data)
+        if notification_data is not None:
+            PropertyBillingNotificationSettings.objects.update_or_create(
+                property=config.property,
+                defaults=notification_data,
+            )
+        return config
+
+    def update(self, instance, validated_data):
+        notification_data = validated_data.pop('notification_settings', None)
+        config = super().update(instance, validated_data)
+        if notification_data is not None:
+            PropertyBillingNotificationSettings.objects.update_or_create(
+                property=config.property,
+                defaults=notification_data,
+            )
+        return config
 
 
 class InvoiceSerializer(serializers.ModelSerializer):
@@ -96,7 +179,10 @@ class ReminderLogSerializer(serializers.ModelSerializer):
 class ChargeTypeSerializer(serializers.ModelSerializer):
     class Meta:
         model = ChargeType
-        fields = ['id', 'property', 'name', 'created_by', 'created_at']
+        fields = [
+            'id', 'property', 'name', 'charge_kind', 'default_amount', 'description',
+            'display_order', 'is_active', 'created_by', 'created_at',
+        ]
         read_only_fields = ['property', 'created_by', 'created_at']
 
 

--- a/billing/serializers.py
+++ b/billing/serializers.py
@@ -69,6 +69,10 @@ class InvoiceCreateSerializer(serializers.Serializer):
         return data
 
 
+class ManualPaymentRecordSerializer(serializers.Serializer):
+    amount = serializers.DecimalField(max_digits=10, decimal_places=2, min_value=Decimal('0.01'))
+
+
 class PaymentSerializer(serializers.ModelSerializer):
     class Meta:
         model = Payment

--- a/billing/tests.py
+++ b/billing/tests.py
@@ -12,7 +12,17 @@ from django.contrib.auth import get_user_model
 
 from authentication.models import Role
 from property.models import Property, Unit, Lease, PropertyAgent
-from billing.models import BillingConfig, Invoice, Payment, Receipt, ReminderLog, ChargeType, AdditionalIncome, Expense
+from billing.models import (
+    BillingConfig,
+    Invoice,
+    Payment,
+    Receipt,
+    ReminderLog,
+    ChargeType,
+    AdditionalIncome,
+    Expense,
+    PropertyBillingNotificationSettings,
+)
 from billing.utils import generate_receipt_number
 
 User = get_user_model()
@@ -103,10 +113,58 @@ class BillingConfigTests(APITestCase):
         response = self.client.post(reverse('billing-config', args=[self.prop.id]), data)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_get_config_not_found(self):
+    def test_get_config_returns_defaults_when_unset(self):
         self.auth(self.landlord_token)
         response = self.client.get(reverse('billing-config', args=[self.prop.id]))
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(response.data['configured'])
+        self.assertEqual(response.data['rent_due_day'], 1)
+        self.assertEqual(response.data['invoice_lead_days'], 0)
+
+    def test_assigned_agent_can_get_billing_config(self):
+        from property.models import PropertyAgent
+        agent, agent_token = make_user('agent_bc', 'Agent')
+        PropertyAgent.objects.create(property=self.prop, agent=agent, appointed_by=self.landlord)
+        self.auth(agent_token)
+        response = self.client.get(reverse('billing-config', args=[self.prop.id]))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_agent_cannot_post_billing_config(self):
+        agent, agent_token = make_user('agent_bc2', 'Agent')
+        from property.models import PropertyAgent
+        PropertyAgent.objects.create(property=self.prop, agent=agent, appointed_by=self.landlord)
+        self.auth(agent_token)
+        response = self.client.post(
+            reverse('billing-config', args=[self.prop.id]),
+            {'rent_due_day': 5, 'grace_period_days': 0, 'late_fee_percentage': '5.00'},
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_late_fee_fixed_mode_requires_amount(self):
+        self.auth(self.landlord_token)
+        response = self.client.post(
+            reverse('billing-config', args=[self.prop.id]),
+            {
+                'rent_due_day': 5,
+                'grace_period_days': 0,
+                'late_fee_percentage': '5.00',
+                'late_fee_mode': 'fixed',
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_invoice_lead_days_above_27_rejected(self):
+        self.auth(self.landlord_token)
+        response = self.client.post(
+            reverse('billing-config', args=[self.prop.id]),
+            {
+                'rent_due_day': 5,
+                'grace_period_days': 0,
+                'late_fee_percentage': '5.00',
+                'invoice_lead_days': 28,
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
 class InvoiceTests(APITestCase):
@@ -373,7 +431,8 @@ class ManualPaymentRecordTests(APITestCase):
     def auth(self, token):
         self.client.credentials(HTTP_AUTHORIZATION=f'Token {token.key}')
 
-    def test_landlord_records_full_payment(self):
+    @patch('notifications.utils.create_notification')
+    def test_landlord_records_full_payment(self, mock_notify):
         self.auth(self.landlord_token)
         response = self.client.post(
             reverse('invoice-payments', args=[self.invoice.id]),
@@ -386,6 +445,21 @@ class ManualPaymentRecordTests(APITestCase):
         self.invoice.refresh_from_db()
         self.assertEqual(self.invoice.status, 'paid')
         self.assertTrue(Receipt.objects.filter(payment_id=response.data['payment']['id']).exists())
+        mock_notify.assert_called_once()
+
+    @patch('notifications.utils.create_notification')
+    def test_manual_payment_skips_notification_when_disabled(self, mock_notify):
+        PropertyBillingNotificationSettings.objects.create(
+            property=self.prop,
+            send_receipt_on_payment=False,
+        )
+        self.auth(self.landlord_token)
+        response = self.client.post(
+            reverse('invoice-payments', args=[self.invoice.id]),
+            {'amount': '45000.00'},
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        mock_notify.assert_not_called()
 
     def test_landlord_partial_then_full(self):
         self.auth(self.landlord_token)
@@ -594,8 +668,8 @@ class ProcessBillingCommandTests(APITestCase):
         self.assertEqual(overdue_invoice.late_fee_amount, Decimal('2250.00'))  # 5% of 45000
         self.assertEqual(overdue_invoice.total_amount, Decimal('47250.00'))
 
-    @patch('billing.management.commands.process_billing.send_mail')
-    def test_pre_due_reminder_sent(self, mock_mail):
+    @patch('notifications.utils.create_notification')
+    def test_pre_due_reminder_sent(self, mock_notify):
         invoice = Invoice.objects.create(
             lease=self.lease,
             period_start=date.today().replace(day=1),
@@ -608,11 +682,11 @@ class ProcessBillingCommandTests(APITestCase):
         )
         from django.core.management import call_command
         call_command('process_billing', verbosity=0)
-        mock_mail.assert_called()
+        mock_notify.assert_called()
         self.assertTrue(ReminderLog.objects.filter(invoice=invoice, reminder_type='pre_due').exists())
 
-    @patch('billing.management.commands.process_billing.send_mail')
-    def test_reminder_not_sent_twice(self, mock_mail):
+    @patch('notifications.utils.create_notification')
+    def test_reminder_not_sent_twice(self, mock_notify):
         invoice = Invoice.objects.create(
             lease=self.lease,
             period_start=date.today().replace(day=1),
@@ -626,7 +700,65 @@ class ProcessBillingCommandTests(APITestCase):
         ReminderLog.objects.create(invoice=invoice, reminder_type='pre_due')
         from django.core.management import call_command
         call_command('process_billing', verbosity=0)
-        mock_mail.assert_not_called()
+        mock_notify.assert_not_called()
+
+    @patch('notifications.utils.create_notification')
+    def test_pre_due_disabled_when_notification_settings_null(self, mock_notify):
+        PropertyBillingNotificationSettings.objects.create(
+            property=self.prop,
+            remind_before_due_days=None,
+        )
+        Invoice.objects.create(
+            lease=self.lease,
+            period_start=date.today().replace(day=1),
+            period_end=date.today(),
+            due_date=date.today() + timedelta(days=3),
+            rent_amount=Decimal('45000'),
+            late_fee_amount=Decimal('0'),
+            total_amount=Decimal('45000'),
+            status='pending',
+        )
+        from django.core.management import call_command
+        call_command('process_billing', verbosity=0)
+        mock_notify.assert_not_called()
+
+    @patch('django.utils.timezone.now')
+    def test_invoice_generated_with_lead_days(self, mock_now):
+        from django.core.management import call_command
+        from django.utils import timezone as dj_tz
+        from datetime import datetime
+
+        mock_now.return_value = dj_tz.make_aware(datetime(2026, 4, 13, 12, 0, 0))
+        cfg = BillingConfig.objects.get(property=self.prop)
+        cfg.rent_due_day = 15
+        cfg.invoice_lead_days = 2
+        cfg.save()
+        call_command('process_billing', verbosity=0)
+        inv = Invoice.objects.filter(lease=self.lease).first()
+        self.assertIsNotNone(inv)
+        self.assertEqual(inv.period_start, date(2026, 4, 1))
+        self.assertEqual(inv.due_date, date(2026, 4, 18))
+
+    def test_late_fee_fixed_mode(self):
+        from django.core.management import call_command
+        cfg = BillingConfig.objects.get(property=self.prop)
+        cfg.late_fee_mode = BillingConfig.LATE_FEE_MODE_FIXED
+        cfg.late_fee_fixed_amount = Decimal('500.00')
+        cfg.save()
+        overdue_invoice = Invoice.objects.create(
+            lease=self.lease,
+            period_start=date.today().replace(day=1),
+            period_end=date.today(),
+            due_date=date.today() - timedelta(days=1),
+            rent_amount=Decimal('45000'),
+            late_fee_amount=Decimal('0'),
+            total_amount=Decimal('45000'),
+            status='pending',
+        )
+        call_command('process_billing', verbosity=0)
+        overdue_invoice.refresh_from_db()
+        self.assertEqual(overdue_invoice.late_fee_amount, Decimal('500.00'))
+        self.assertEqual(overdue_invoice.total_amount, Decimal('45500.00'))
 
 
 class ChargeTypeTests(APITestCase):
@@ -693,6 +825,79 @@ class ChargeTypeTests(APITestCase):
         self.auth(self.landlord_token)
         response = self.client.delete(reverse('charge-type-detail', args=[self.prop.id, ct.id]))
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_cannot_delete_charge_type_with_income_entries(self):
+        ct = ChargeType.objects.create(property=self.prop, name='Garbage', created_by=self.landlord)
+        unit = make_unit(self.prop, self.landlord)
+        AdditionalIncome.objects.create(
+            unit=unit, charge_type=ct, amount=Decimal('100'), date=date.today(), recorded_by=self.landlord
+        )
+        self.auth(self.landlord_token)
+        response = self.client.delete(reverse('charge-type-detail', args=[self.prop.id, ct.id]))
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_inactive_charge_types_hidden_by_default(self):
+        ChargeType.objects.create(
+            property=self.prop, name='Old', created_by=self.landlord, is_active=False
+        )
+        ChargeType.objects.create(property=self.prop, name='New', created_by=self.landlord, is_active=True)
+        self.auth(self.landlord_token)
+        response = self.client.get(reverse('charge-type-list', args=[self.prop.id]))
+        self.assertEqual(len(response.data), 1)
+        response_all = self.client.get(
+            reverse('charge-type-list', args=[self.prop.id]) + '?include_inactive=1'
+        )
+        self.assertEqual(len(response_all.data), 2)
+
+
+class BillingPreviewTests(APITestCase):
+    def setUp(self):
+        self.landlord, self.landlord_token = make_user('landlord_pv', 'Landlord')
+        self.agent, self.agent_token = make_user('agent_pv', 'Agent')
+        self.tenant, _ = make_user('tenant_pv', 'Tenant')
+        self.prop = make_property(self.landlord)
+        self.unit = make_unit(self.prop, self.landlord)
+        make_lease(self.unit, self.tenant)
+
+    def auth(self, token):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {token.key}')
+
+    def test_preview_requires_config_for_dates(self):
+        self.auth(self.landlord_token)
+        response = self.client.get(reverse('billing-preview', args=[self.prop.id]))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(response.data['configured'])
+        self.assertIsNone(response.data['next_invoice_generation_date'])
+
+    def test_preview_with_config(self):
+        BillingConfig.objects.create(
+            property=self.prop,
+            rent_due_day=15,
+            grace_period_days=3,
+            late_fee_percentage='5.00',
+            invoice_lead_days=2,
+            updated_by=self.landlord,
+        )
+        self.auth(self.landlord_token)
+        response = self.client.get(reverse('billing-preview', args=[self.prop.id]))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.data['configured'])
+        self.assertEqual(response.data['invoice_lead_days'], 2)
+        self.assertEqual(response.data['active_lease_count'], 1)
+
+    def test_assigned_agent_can_preview(self):
+        from property.models import PropertyAgent
+        BillingConfig.objects.create(
+            property=self.prop,
+            rent_due_day=5,
+            grace_period_days=0,
+            late_fee_percentage='5.00',
+            updated_by=self.landlord,
+        )
+        PropertyAgent.objects.create(property=self.prop, agent=self.agent, appointed_by=self.landlord)
+        self.auth(self.agent_token)
+        response = self.client.get(reverse('billing-preview', args=[self.prop.id]))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
 
 class AdditionalIncomeTests(APITestCase):

--- a/billing/tests.py
+++ b/billing/tests.py
@@ -348,6 +348,127 @@ class PaymentTests(APITestCase):
         response = self.client.post(reverse('invoice-pay', args=[self.invoice.id]), {})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_tenant_cannot_record_manual_payment(self):
+        self.auth(self.tenant_token)
+        response = self.client.post(
+            reverse('invoice-payments', args=[self.invoice.id]),
+            {'amount': '45000.00'},
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
+class ManualPaymentRecordTests(APITestCase):
+    def setUp(self):
+        self.landlord, self.landlord_token = make_user('landlord_mp', 'Landlord')
+        self.other_landlord, self.other_token = make_user('landlord_mp2', 'Landlord')
+        self.tenant, self.tenant_token = make_user('tenant_mp', 'Tenant')
+        self.agent, self.agent_token = make_user('agent_mp', 'Agent')
+        self.admin, self.admin_token = make_user('admin_mp', 'Admin', is_staff=True)
+
+        self.prop = make_property(self.landlord)
+        self.unit = make_unit(self.prop, self.landlord)
+        self.lease = make_lease(self.unit, self.tenant)
+        self.invoice = make_invoice(self.lease)
+
+    def auth(self, token):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {token.key}')
+
+    def test_landlord_records_full_payment(self):
+        self.auth(self.landlord_token)
+        response = self.client.post(
+            reverse('invoice-payments', args=[self.invoice.id]),
+            {'amount': '45000.00'},
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(response.data['payment']['stripe_payment_intent_id'].startswith('manual-'))
+        self.assertEqual(response.data['payment']['status'], 'completed')
+        self.assertIn('receipt_number', response.data['receipt'])
+        self.invoice.refresh_from_db()
+        self.assertEqual(self.invoice.status, 'paid')
+        self.assertTrue(Receipt.objects.filter(payment_id=response.data['payment']['id']).exists())
+
+    def test_landlord_partial_then_full(self):
+        self.auth(self.landlord_token)
+        r1 = self.client.post(
+            reverse('invoice-payments', args=[self.invoice.id]),
+            {'amount': '20000.00'},
+        )
+        self.assertEqual(r1.status_code, status.HTTP_201_CREATED)
+        self.invoice.refresh_from_db()
+        self.assertEqual(self.invoice.status, 'partial')
+        r2 = self.client.post(
+            reverse('invoice-payments', args=[self.invoice.id]),
+            {'amount': '25000.00'},
+        )
+        self.assertEqual(r2.status_code, status.HTTP_201_CREATED)
+        self.invoice.refresh_from_db()
+        self.assertEqual(self.invoice.status, 'paid')
+
+    def test_amount_exceeds_remaining_returns_400(self):
+        self.auth(self.landlord_token)
+        response = self.client.post(
+            reverse('invoice-payments', args=[self.invoice.id]),
+            {'amount': '50000.00'},
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_fully_paid_cannot_record_more(self):
+        self.auth(self.landlord_token)
+        self.client.post(
+            reverse('invoice-payments', args=[self.invoice.id]),
+            {'amount': '45000.00'},
+        )
+        response = self.client.post(
+            reverse('invoice-payments', args=[self.invoice.id]),
+            {'amount': '1.00'},
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_cancelled_invoice_rejected(self):
+        self.invoice.status = 'cancelled'
+        self.invoice.save()
+        self.auth(self.landlord_token)
+        response = self.client.post(
+            reverse('invoice-payments', args=[self.invoice.id]),
+            {'amount': '45000.00'},
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_assigned_agent_can_record(self):
+        PropertyAgent.objects.create(
+            property=self.prop, agent=self.agent, appointed_by=self.landlord
+        )
+        self.auth(self.agent_token)
+        response = self.client.post(
+            reverse('invoice-payments', args=[self.invoice.id]),
+            {'amount': '45000.00'},
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_unassigned_agent_forbidden(self):
+        self.auth(self.agent_token)
+        response = self.client.post(
+            reverse('invoice-payments', args=[self.invoice.id]),
+            {'amount': '45000.00'},
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_other_landlord_forbidden(self):
+        self.auth(self.other_token)
+        response = self.client.post(
+            reverse('invoice-payments', args=[self.invoice.id]),
+            {'amount': '45000.00'},
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_admin_can_record(self):
+        self.auth(self.admin_token)
+        response = self.client.post(
+            reverse('invoice-payments', args=[self.invoice.id]),
+            {'amount': '45000.00'},
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
 
 class ReceiptTests(APITestCase):
     def setUp(self):

--- a/billing/urls.py
+++ b/billing/urls.py
@@ -3,6 +3,7 @@ from . import views
 
 urlpatterns = [
     path('config/<int:property_id>/', views.billing_config, name='billing-config'),
+    path('properties/<int:property_pk>/billing-preview/', views.billing_preview, name='billing-preview'),
     path('invoices/', views.invoice_list, name='invoice-list'),
     path('invoices/<int:pk>/', views.invoice_detail, name='invoice-detail'),
     path('invoices/<int:pk>/pay/', views.pay_invoice, name='invoice-pay'),

--- a/billing/views.py
+++ b/billing/views.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 import stripe
 from django.conf import settings
 from django.utils import timezone
@@ -11,7 +12,7 @@ from drf_spectacular.utils import extend_schema, OpenApiExample
 
 from decimal import Decimal
 
-from django.db import IntegrityError
+from django.db import IntegrityError, transaction
 from django.db.models import Sum, Count
 
 from property.models import Property, Unit, Lease
@@ -19,6 +20,7 @@ from property.views import is_admin, is_landlord, is_agent_for
 from .models import BillingConfig, Invoice, Payment, Receipt, ChargeType, AdditionalIncome, Expense
 from .serializers import (
     BillingConfigSerializer, InvoiceSerializer, InvoiceCreateSerializer,
+    ManualPaymentRecordSerializer,
     PaymentSerializer, ReceiptSerializer,
     ChargeTypeSerializer, AdditionalIncomeSerializer, ExpenseSerializer,
 )
@@ -229,7 +231,18 @@ def pay_invoice(request, pk):
 
 
 @extend_schema(methods=['GET'], summary="List payments for an invoice")
-@api_view(['GET'])
+@extend_schema(
+    methods=['POST'],
+    summary="Record a manual payment (cash, bank transfer, etc.)",
+    examples=[
+        OpenApiExample(
+            "Record manual payment",
+            request_only=True,
+            value={'amount': '25000.00'},
+        ),
+    ],
+)
+@api_view(['GET', 'POST'])
 @permission_classes([IsAuthenticated])
 def invoice_payments(request, pk):
     try:
@@ -243,8 +256,61 @@ def invoice_payments(request, pk):
     if not (is_admin(user) or prop.owner == user or is_agent_for(user, prop) or is_tenant):
         return Response({'detail': 'Permission denied.'}, status=status.HTTP_403_FORBIDDEN)
 
-    payments = invoice.payments.all()
-    return Response(PaymentSerializer(payments, many=True).data)
+    if request.method == 'GET':
+        payments = invoice.payments.all()
+        return Response(PaymentSerializer(payments, many=True).data)
+
+    if not (is_admin(user) or prop.owner == user or is_agent_for(user, prop)):
+        return Response({'detail': 'Permission denied.'}, status=status.HTTP_403_FORBIDDEN)
+
+    if invoice.status == 'cancelled':
+        return Response({'detail': 'Invoice is cancelled.'}, status=status.HTTP_400_BAD_REQUEST)
+
+    serializer = ManualPaymentRecordSerializer(data=request.data)
+    if not serializer.is_valid():
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    amount = serializer.validated_data['amount']
+    remaining = invoice.total_amount - invoice.amount_paid()
+    if remaining <= 0:
+        return Response(
+            {'detail': 'Invoice balance is already fully paid.'},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+    if amount > remaining:
+        return Response(
+            {'detail': f'Amount exceeds remaining balance ({remaining}).'},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    manual_ref = f'manual-{uuid.uuid4().hex}'
+    try:
+        with transaction.atomic():
+            payment = Payment.objects.create(
+                invoice=invoice,
+                amount=amount,
+                stripe_payment_intent_id=manual_ref,
+                status='completed',
+                paid_at=timezone.now(),
+            )
+            invoice.update_status()
+            receipt = Receipt.objects.create(
+                payment=payment,
+                receipt_number=generate_receipt_number(),
+            )
+    except IntegrityError:
+        return Response(
+            {'detail': 'Could not record payment. Try again.'},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    return Response(
+        {
+            'payment': PaymentSerializer(payment).data,
+            'receipt': ReceiptSerializer(receipt).data,
+        },
+        status=status.HTTP_201_CREATED,
+    )
 
 
 # ── Stripe Webhook ─────────────────────────────────────────────────────────────

--- a/billing/views.py
+++ b/billing/views.py
@@ -1,6 +1,9 @@
+import calendar
 import json
 import uuid
 import stripe
+from datetime import date, timedelta
+
 from django.conf import settings
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
@@ -17,7 +20,16 @@ from django.db.models import Sum, Count
 
 from property.models import Property, Unit, Lease
 from property.views import is_admin, is_landlord, is_agent_for
-from .models import BillingConfig, Invoice, Payment, Receipt, ChargeType, AdditionalIncome, Expense
+from .models import (
+    BillingConfig,
+    Invoice,
+    Payment,
+    Receipt,
+    ChargeType,
+    AdditionalIncome,
+    Expense,
+    PropertyBillingNotificationSettings,
+)
 from .serializers import (
     BillingConfigSerializer, InvoiceSerializer, InvoiceCreateSerializer,
     ManualPaymentRecordSerializer,
@@ -27,6 +39,52 @@ from .serializers import (
 from .utils import generate_receipt_number
 
 stripe.api_key = settings.STRIPE_SECRET_KEY
+
+
+def _property_sends_receipt_on_payment(prop):
+    try:
+        return prop.billing_notification_settings.send_receipt_on_payment
+    except PropertyBillingNotificationSettings.DoesNotExist:
+        return True
+
+
+def _notify_tenant_payment_received(invoice, amount, receipt_number):
+    if not _property_sends_receipt_on_payment(invoice.lease.unit.property):
+        return
+    from notifications.utils import create_notification
+
+    tenant = invoice.lease.tenant
+    create_notification(
+        tenant,
+        'payment',
+        'Payment received',
+        (
+            f'Hi {tenant.first_name or tenant.username},\n\n'
+            f'We recorded a payment of KES {amount} toward invoice #{invoice.id}.\n'
+            f'Receipt: {receipt_number}\n\n'
+            f'Tree House'
+        ),
+        action_url='',
+    )
+
+
+def _billing_clamp_due_day(due_day, year, month):
+    return min(due_day, calendar.monthrange(year, month)[1])
+
+
+def _next_invoice_generation_on_or_after(start, rent_due_day, lead_days):
+    for i in range(370):
+        d = start + timedelta(days=i)
+        cd = _billing_clamp_due_day(rent_due_day, d.year, d.month)
+        gen_d = max(1, cd - lead_days)
+        if d.day == gen_d:
+            return d
+    return None
+
+
+def _next_rent_anchor_from_gen(gen_date, rent_due_day):
+    cd = _billing_clamp_due_day(rent_due_day, gen_date.year, gen_date.month)
+    return date(gen_date.year, gen_date.month, cd)
 
 
 # ── Billing Config ─────────────────────────────────────────────────────────────
@@ -41,6 +99,19 @@ stripe.api_key = settings.STRIPE_SECRET_KEY
             "grace_period_days": 3,
             "late_fee_percentage": "5.00",
             "late_fee_max_percentage": "20.00",
+            "invoice_lead_days": 0,
+            "late_fee_mode": "percentage",
+            "late_fee_fixed_amount": None,
+            "mpesa_paybill": "123456",
+            "mpesa_account_label": "Unit code + phone",
+            "bank_name": "Example Bank",
+            "bank_account": "0123456789",
+            "payment_notes": "Reference: invoice number",
+            "notification_settings": {
+                "remind_before_due_days": 3,
+                "remind_after_overdue_days": 0,
+                "send_receipt_on_payment": True,
+            },
         })
     ],
 )
@@ -52,7 +123,10 @@ def billing_config(request, property_id):
     except Property.DoesNotExist:
         return Response({'detail': 'Property not found.'}, status=status.HTTP_404_NOT_FOUND)
 
-    if not (is_admin(request.user) or property.owner == request.user):
+    can_read = is_admin(request.user) or property.owner == request.user or is_agent_for(request.user, property)
+    can_write = is_admin(request.user) or property.owner == request.user
+
+    if not can_read:
         return Response({'detail': 'Permission denied.'}, status=status.HTTP_403_FORBIDDEN)
 
     if request.method == 'GET':
@@ -60,9 +134,27 @@ def billing_config(request, property_id):
             config = property.billing_config
             return Response(BillingConfigSerializer(config).data)
         except BillingConfig.DoesNotExist:
-            return Response({'detail': 'No billing config set for this property.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response({
+                'configured': False,
+                'property': property.id,
+                'rent_due_day': 1,
+                'grace_period_days': 0,
+                'late_fee_percentage': '0.00',
+                'late_fee_max_percentage': None,
+                'invoice_lead_days': 0,
+                'late_fee_mode': BillingConfig.LATE_FEE_MODE_PERCENTAGE,
+                'late_fee_fixed_amount': None,
+                'mpesa_paybill': '',
+                'mpesa_account_label': '',
+                'bank_name': '',
+                'bank_account': '',
+                'payment_notes': '',
+                'notification_settings': None,
+            })
 
     elif request.method == 'POST':
+        if not can_write:
+            return Response({'detail': 'Permission denied.'}, status=status.HTTP_403_FORBIDDEN)
         try:
             config = property.billing_config
             serializer = BillingConfigSerializer(config, data=request.data, partial=True)
@@ -70,8 +162,8 @@ def billing_config(request, property_id):
             serializer = BillingConfigSerializer(data=request.data)
 
         if serializer.is_valid():
-            serializer.save(property=property, updated_by=request.user)
-            return Response(serializer.data, status=status.HTTP_200_OK)
+            instance = serializer.save(property=property, updated_by=request.user)
+            return Response(BillingConfigSerializer(instance).data, status=status.HTTP_200_OK)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
@@ -298,6 +390,7 @@ def invoice_payments(request, pk):
                 payment=payment,
                 receipt_number=generate_receipt_number(),
             )
+            _notify_tenant_payment_received(invoice, amount, receipt.receipt_number)
     except IntegrityError:
         return Response(
             {'detail': 'Could not record payment. Try again.'},
@@ -356,10 +449,11 @@ def _handle_payment_success(intent):
 
     # Auto-generate receipt
     if not hasattr(payment, 'receipt'):
-        Receipt.objects.create(
+        receipt = Receipt.objects.create(
             payment=payment,
             receipt_number=generate_receipt_number(),
         )
+        _notify_tenant_payment_received(payment.invoice, payment.amount, receipt.receipt_number)
 
 
 def _handle_payment_failure(intent):
@@ -436,8 +530,10 @@ def charge_type_list_create(request, property_pk):
         return Response({'detail': 'Permission denied.'}, status=status.HTTP_403_FORBIDDEN)
 
     if request.method == 'GET':
-        charge_types = prop.charge_types.all()
-        return Response(ChargeTypeSerializer(charge_types, many=True).data)
+        qs = prop.charge_types.all().order_by('display_order', 'id')
+        if request.query_params.get('include_inactive') not in ('1', 'true', 'yes'):
+            qs = qs.filter(is_active=True)
+        return Response(ChargeTypeSerializer(qs, many=True).data)
 
     elif request.method == 'POST':
         if not (is_admin(user) or prop.owner == user):
@@ -492,6 +588,11 @@ def charge_type_detail(request, property_pk, pk):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     elif request.method == 'DELETE':
+        if AdditionalIncome.objects.filter(charge_type=charge_type).exists():
+            return Response(
+                {'detail': 'Charge type has income entries; set is_active=false instead of deleting.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         charge_type.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -677,6 +778,79 @@ def expense_detail(request, property_pk, pk):
     elif request.method == 'DELETE':
         expense.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+# ── Billing preview ─────────────────────────────────────────────────────────────
+
+@extend_schema(
+    methods=['GET'],
+    summary="Preview next invoice generation date and rent roll for a property",
+    examples=[
+        OpenApiExample(
+            "Preview",
+            value={
+                'configured': True,
+                'property': 1,
+                'invoice_lead_days': 2,
+                'rent_due_day': 5,
+                'grace_period_days': 3,
+                'next_invoice_generation_date': '2026-04-03',
+                'next_rent_due_date': '2026-04-08',
+                'active_lease_count': 4,
+                'estimated_monthly_rent_total': '180000.00',
+            },
+        ),
+    ],
+)
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
+def billing_preview(request, property_pk):
+    try:
+        prop = Property.objects.get(pk=property_pk)
+    except Property.DoesNotExist:
+        return Response({'detail': 'Property not found.'}, status=status.HTTP_404_NOT_FOUND)
+
+    user = request.user
+    if not (is_admin(user) or prop.owner == user or is_agent_for(user, prop)):
+        return Response({'detail': 'Permission denied.'}, status=status.HTTP_403_FORBIDDEN)
+
+    today = timezone.now().date()
+    active = Lease.objects.filter(unit__property=prop, is_active=True)
+    lease_count = active.count()
+    rent_total = active.aggregate(t=Sum('rent_amount'))['t'] or Decimal('0')
+
+    try:
+        config = prop.billing_config
+    except BillingConfig.DoesNotExist:
+        return Response({
+            'configured': False,
+            'property': prop.id,
+            'invoice_lead_days': 0,
+            'rent_due_day': 1,
+            'grace_period_days': 0,
+            'next_invoice_generation_date': None,
+            'next_rent_due_date': None,
+            'active_lease_count': lease_count,
+            'estimated_monthly_rent_total': str(rent_total),
+        })
+
+    next_gen = _next_invoice_generation_on_or_after(today, config.rent_due_day, config.invoice_lead_days)
+    next_due = None
+    if next_gen:
+        anchor = _next_rent_anchor_from_gen(next_gen, config.rent_due_day)
+        next_due = anchor + timedelta(days=config.grace_period_days)
+
+    return Response({
+        'configured': True,
+        'property': prop.id,
+        'invoice_lead_days': config.invoice_lead_days,
+        'rent_due_day': config.rent_due_day,
+        'grace_period_days': config.grace_period_days,
+        'next_invoice_generation_date': next_gen,
+        'next_rent_due_date': next_due,
+        'active_lease_count': lease_count,
+        'estimated_monthly_rent_total': str(rent_total),
+    })
 
 
 # ── Financial Report ────────────────────────────────────────────────────────────

--- a/docs/api-integration.md
+++ b/docs/api-integration.md
@@ -49,6 +49,7 @@ Content-Type: `application/json`
 | Configure billing | ✗ | ✓ | Own | ✗ | ✗ | ✗ | ✗ |
 | List / view invoices | ✗ | All | Own | Assigned | Own | ✗ | ✗ |
 | Create invoice (manual) | ✗ | ✓ | Own | Assigned | ✗ | ✗ | ✗ |
+| Record manual invoice payment | ✗ | ✓ | Own | Assigned | ✗ | ✗ | ✗ |
 | Pay invoice (Stripe) | ✗ | ✗ | ✗ | ✗ | Own | ✗ | ✗ |
 | View payments & receipts | ✗ | All | Own | Assigned | Own | ✗ | ✗ |
 | Manage charge types | ✗ | ✓ | Own | View only | ✗ | ✗ | ✗ |
@@ -727,6 +728,78 @@ Use this to issue a rent invoice outside the automatic `process_billing` schedul
 | Duplicate `period_start` for that lease | `400` — `An invoice for this lease and period_start already exists.` |
 | Lease inactive or period outside lease dates | `400` — field errors from validation |
 | `period_end` before `period_start` | `400` |
+
+---
+
+### List payments for an invoice
+`GET /api/billing/invoices/<pk>/payments/`
+
+Same visibility as invoice detail: **admin**, **property owner**, **assigned agent**, or **tenant on the lease**.
+
+```json
+[
+  {
+    "id": 3,
+    "invoice": 1,
+    "amount": "25000.00",
+    "stripe_payment_intent_id": "pi_xxx",
+    "stripe_charge_id": "ch_xxx",
+    "status": "completed",
+    "paid_at": "2024-02-15T10:30:00Z",
+    "created_at": "2024-02-15T10:29:00Z"
+  }
+]
+```
+
+Manual (non-Stripe) payments use a synthetic `stripe_payment_intent_id` starting with `manual-`.
+
+---
+
+### Record manual payment (Owner / Assigned Agent / Admin)
+`POST /api/billing/invoices/<pk>/payments/`
+
+Use when rent was collected **outside Stripe** (cash, M-Pesa, bank transfer, etc.). Creates a **completed** `Payment`, generates a **receipt** (same numbering as Stripe flow), and refreshes the invoice status (`partial` or `paid`).
+
+**Who can call:** platform admin, property owner, or agent assigned to the property. The tenant must use **`POST .../pay/`** for Stripe instead.
+
+**Rules:**
+- `amount` is required (decimal string). It must not exceed the **remaining balance** (`total_amount` minus sum of completed payments).
+- Cannot record on a **cancelled** invoice or when the balance is already **zero**.
+- Multiple POSTs are allowed for **partial** payments until the invoice is fully paid.
+
+```json
+// Request
+{ "amount": "25000.00" }
+```
+
+```json
+// Response 201
+{
+  "payment": {
+    "id": 4,
+    "invoice": 1,
+    "amount": "25000.00",
+    "stripe_payment_intent_id": "manual-abc123...",
+    "stripe_charge_id": "",
+    "status": "completed",
+    "paid_at": "2024-02-15T11:00:00Z",
+    "created_at": "2024-02-15T11:00:00Z"
+  },
+  "receipt": {
+    "id": 2,
+    "payment": 4,
+    "receipt_number": "RCP-202402-0002",
+    "issued_at": "2024-02-15T11:00:00Z"
+  }
+}
+```
+
+| Error | Status |
+|-------|--------|
+| Tenant or unrelated user | `403` |
+| Invoice cancelled | `400` |
+| Balance already zero | `400` |
+| Amount over remaining balance | `400` |
 
 ---
 

--- a/notifications/migrations/0002_alter_notification_notification_type.py
+++ b/notifications/migrations/0002_alter_notification_notification_type.py
@@ -1,0 +1,30 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('notifications', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='notification',
+            name='notification_type',
+            field=models.CharField(
+                max_length=20,
+                choices=[
+                    ('message', 'New Message'),
+                    ('maintenance', 'Maintenance Update'),
+                    ('payment', 'Payment'),
+                    ('payment_reminder', 'Payment Due Reminder'),
+                    ('lease', 'Lease'),
+                    ('dispute', 'Dispute'),
+                    ('application', 'Application'),
+                    ('new_listing', 'New Listing Match'),
+                    ('moving', 'Moving Booking'),
+                    ('account', 'Account Update'),
+                ],
+            ),
+        ),
+    ]

--- a/notifications/models.py
+++ b/notifications/models.py
@@ -7,6 +7,7 @@ class Notification(models.Model):
         ('message', 'New Message'),
         ('maintenance', 'Maintenance Update'),
         ('payment', 'Payment'),
+        ('payment_reminder', 'Payment Due Reminder'),
         ('lease', 'Lease'),
         ('dispute', 'Dispute'),
         ('application', 'Application'),

--- a/notifications/utils.py
+++ b/notifications/utils.py
@@ -3,7 +3,7 @@ def create_notification(user, notification_type, title, body, action_url=''):
     Creates an in-app Notification record.
     Also sends an email if the user's NotificationPreference allows it.
 
-    notification_type must be one of: message, maintenance, payment, lease, dispute, application
+    notification_type must be one of the Notification.NOTIFICATION_TYPES values (e.g. message, maintenance, payment, payment_reminder, lease, dispute, application, …).
     """
     from .models import Notification
     notification = Notification.objects.create(
@@ -37,6 +37,7 @@ def _maybe_send_email(user, notification_type, title, body):
         'message': True,  # always send message notifications if email_notifications is on
         'maintenance': prefs.maintenance_updates,
         'payment': prefs.payment_received,
+        'payment_reminder': prefs.payment_due_reminder,
         'lease': prefs.lease_expiry_notice,
         'dispute': True,  # always send dispute notifications
         'application': prefs.application_status_change,


### PR DESCRIPTION
Landlord, assigned agent, or admin can record completed payments and receipts off-Stripe; tenants remain Stripe-only on /pay/.

Made-with: Cursor

## Summary by Sourcery

Add support for recording manual (non-Stripe) payments against invoices via the existing invoice payments endpoint.

New Features:
- Allow POST /api/billing/invoices/<pk>/payments/ to record completed manual payments that create a Payment and Receipt and update invoice status.

Enhancements:
- Restrict manual payment recording to admins, property owners, and assigned agents, while keeping tenants limited to Stripe-based payments.
- Validate manual payment amounts against the remaining invoice balance and block recording on cancelled or fully paid invoices.

Documentation:
- Document the new manual payment recording workflow, permissions, request/response format, and error conditions in the API integration guide.
- Update internal API capability matrix to reflect GET/POST behaviour for /api/billing/invoices/<pk>/payments/.

Tests:
- Add API tests covering role-based access, partial and full manual payments, overpayment attempts, cancelled invoices, and fully paid invoices for the invoice payments endpoint.