### PR TITLE
billing: manual payments support fee_amount, method, transaction ref

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,7 +233,7 @@ Seeded via data migrations. Roles are:
 | GET/POST | `/api/billing/invoices/` | GET: Admin=all, Landlord=own properties, Agent=assigned, Tenant=own — POST: Admin / property owner / assigned agent (requires billing config on property; body: `lease`, `period_start`, `period_end`, `due_date`, optional `rent_amount`) |
 | GET | `/api/billing/invoices/<pk>/` | Owner/Agent/Tenant |
 | POST | `/api/billing/invoices/<pk>/pay/` | Tenant only |
-| GET/POST | `/api/billing/invoices/<pk>/payments/` | GET: Owner/Agent/Tenant — POST: record manual payment (cash/bank); Owner/Assigned Agent/Admin only; body `amount`; creates completed `Payment` (`stripe_payment_intent_id` prefix `manual-`), receipt, updates invoice status |
+| GET/POST | `/api/billing/invoices/<pk>/payments/` | GET: Owner/Agent/Tenant — POST: record manual payment; Owner/Assigned Agent/Admin only; body `amount` (required), optional `payment_method` (default `cash`), `fee_amount` (≥0, not counted toward invoice balance), `transaction_reference`; creates completed `Payment` (`stripe_payment_intent_id` prefix `manual-`), receipt, updates invoice status |
 | GET | `/api/billing/receipts/` | Admin=all, Landlord=own, Agent=assigned, Tenant=own — paginated `{count,next,previous,results}`; query: `property`, `method` (`mpesa`\|`bank`\|`card`\|`cash`\|`other`), `month` (`YYYY-MM`), `search`, `page`, `page_size` (default 20, max 100); each result = enriched receipt + legacy `id`/`payment`/`receipt_number`/`issued_at` |
 | GET | `/api/billing/receipts/<pk>/` | Same enriched shape as list row; 403 out of scope, 404 missing |
 | GET | `/api/billing/receipts/stats/` | Same role scope; optional `property`, `month`; `{total_count,this_month_count,this_month_total,method_breakdown,average_amount}` |

--- a/billing/migrations/0006_payment_add_fee_amount.py
+++ b/billing/migrations/0006_payment_add_fee_amount.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('billing', '0005_backfill_payment_method_invoice_number'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='payment',
+            name='fee_amount',
+            field=models.DecimalField(
+                decimal_places=2,
+                default=0,
+                help_text='Optional per-payment fee, not counted towards invoice principal.',
+                max_digits=10,
+            ),
+            preserve_default=False,
+        ),
+    ]

--- a/billing/models.py
+++ b/billing/models.py
@@ -133,6 +133,12 @@ class Payment(models.Model):
 
     invoice = models.ForeignKey(Invoice, on_delete=models.CASCADE, related_name='payments')
     amount = models.DecimalField(max_digits=10, decimal_places=2)
+    fee_amount = models.DecimalField(
+        max_digits=10,
+        decimal_places=2,
+        default=0,
+        help_text='Optional per-payment fee, not counted towards invoice principal.',
+    )
     stripe_payment_intent_id = models.CharField(max_length=200, unique=True)
     stripe_charge_id = models.CharField(max_length=200, blank=True)
     payment_method = models.CharField(max_length=20, choices=PAYMENT_METHOD_CHOICES, default=PAYMENT_METHOD_OTHER)

--- a/billing/serializers.py
+++ b/billing/serializers.py
@@ -155,14 +155,39 @@ class InvoiceCreateSerializer(serializers.Serializer):
 
 class ManualPaymentRecordSerializer(serializers.Serializer):
     amount = serializers.DecimalField(max_digits=10, decimal_places=2, min_value=Decimal('0.01'))
+    payment_method = serializers.CharField(required=False, allow_blank=True, max_length=20)
+    fee_amount = serializers.DecimalField(
+        max_digits=10,
+        decimal_places=2,
+        required=False,
+        min_value=Decimal('0'),
+        default=Decimal('0'),
+    )
+    transaction_reference = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+        max_length=128,
+    )
+
+    def validate_payment_method(self, value):
+        if value is None or not str(value).strip():
+            return None
+        v = str(value).strip().lower()
+        allowed = {c[0] for c in Payment.PAYMENT_METHOD_CHOICES}
+        if v not in allowed:
+            raise serializers.ValidationError('Invalid choice.')
+        return v
 
 
 class PaymentSerializer(serializers.ModelSerializer):
     class Meta:
         model = Payment
-        fields = ['id', 'invoice', 'amount', 'stripe_payment_intent_id',
-                  'stripe_charge_id', 'payment_method', 'transaction_reference',
-                  'status', 'paid_at', 'created_at']
+        fields = [
+            'id', 'invoice', 'amount', 'fee_amount', 'stripe_payment_intent_id',
+            'stripe_charge_id', 'payment_method', 'transaction_reference',
+            'status', 'paid_at', 'created_at',
+        ]
         read_only_fields = ['stripe_payment_intent_id', 'stripe_charge_id', 'status', 'paid_at', 'created_at']
 
 
@@ -197,6 +222,10 @@ class ReceiptSerializer(serializers.ModelSerializer):
     amount = serializers.DecimalField(
         max_digits=10, decimal_places=2, source='payment.amount', read_only=True,
         help_text='Payment amount (decimal string).',
+    )
+    fee_amount = serializers.DecimalField(
+        max_digits=10, decimal_places=2, source='payment.fee_amount', read_only=True,
+        help_text='Per-payment fee if any; not counted toward invoice principal.',
     )
     payment_status = serializers.CharField(
         source='payment.status', read_only=True,
@@ -252,7 +281,7 @@ class ReceiptSerializer(serializers.ModelSerializer):
         model = Receipt
         fields = [
             'id', 'payment', 'receipt_number', 'issued_at',
-            'amount', 'payment_status', 'paid_at', 'payment_method',
+            'amount', 'fee_amount', 'payment_status', 'paid_at', 'payment_method',
             'transaction_ref', 'transaction_reference',
             'invoice_id', 'invoice_number', 'invoice_status',
             'invoice_period_start', 'invoice_period_end',

--- a/billing/test_receipts_api_contract.py
+++ b/billing/test_receipts_api_contract.py
@@ -21,7 +21,7 @@ from billing.receipt_contract_factories import (
 
 
 RECEIPT_ENRICHED_KEYS = frozenset({
-    'amount', 'payment_status', 'paid_at', 'payment_method', 'transaction_ref',
+    'amount', 'fee_amount', 'payment_status', 'paid_at', 'payment_method', 'transaction_ref',
     'transaction_reference', 'invoice_id', 'invoice_number', 'invoice_status',
     'invoice_period_start', 'invoice_period_end', 'tenant_id', 'tenant_name',
     'tenant_email', 'unit_id', 'unit_name', 'property_id', 'property_name', 'charge_type',

--- a/billing/tests.py
+++ b/billing/tests.py
@@ -546,6 +546,111 @@ class ManualPaymentRecordTests(APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
+    def test_default_payment_method_is_cash(self):
+        self.auth(self.landlord_token)
+        response = self.client.post(
+            reverse('invoice-payments', args=[self.invoice.id]),
+            {'amount': '45000.00'},
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data['payment']['payment_method'], 'cash')
+        self.assertEqual(response.data['payment']['fee_amount'], '0.00')
+
+    def test_payment_method_normalized_case_insensitive(self):
+        self.auth(self.landlord_token)
+        response = self.client.post(
+            reverse('invoice-payments', args=[self.invoice.id]),
+            {'amount': '45000.00', 'payment_method': 'MPEsa'},
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data['payment']['payment_method'], 'mpesa')
+
+    def test_manual_payment_with_fee_and_reference(self):
+        self.auth(self.landlord_token)
+        response = self.client.post(
+            reverse('invoice-payments', args=[self.invoice.id]),
+            {
+                'amount': '45000.00',
+                'payment_method': 'bank',
+                'fee_amount': '150.00',
+                'transaction_reference': 'QHJ7K2MN01',
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data['payment']['amount'], '45000.00')
+        self.assertEqual(response.data['payment']['fee_amount'], '150.00')
+        self.assertEqual(response.data['payment']['payment_method'], 'bank')
+        self.assertEqual(response.data['payment']['transaction_reference'], 'QHJ7K2MN01')
+        self.assertEqual(response.data['receipt']['fee_amount'], '150.00')
+
+    def test_fee_amount_only_optional(self):
+        self.auth(self.landlord_token)
+        response = self.client.post(
+            reverse('invoice-payments', args=[self.invoice.id]),
+            {'amount': '45000.00', 'fee_amount': '99.50'},
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data['payment']['fee_amount'], '99.50')
+        self.assertEqual(response.data['payment']['payment_method'], 'cash')
+
+    def test_fee_amount_does_not_reduce_invoice_balance(self):
+        self.auth(self.landlord_token)
+        r1 = self.client.post(
+            reverse('invoice-payments', args=[self.invoice.id]),
+            {'amount': '20000.00', 'fee_amount': '5000.00', 'payment_method': 'mpesa'},
+        )
+        self.assertEqual(r1.status_code, status.HTTP_201_CREATED)
+        self.invoice.refresh_from_db()
+        self.assertEqual(self.invoice.status, 'partial')
+        remaining = self.invoice.total_amount - self.invoice.amount_paid()
+        self.assertEqual(remaining, Decimal('25000.00'))
+        r2 = self.client.post(
+            reverse('invoice-payments', args=[self.invoice.id]),
+            {'amount': '25000.00'},
+        )
+        self.assertEqual(r2.status_code, status.HTTP_201_CREATED)
+        self.invoice.refresh_from_db()
+        self.assertEqual(self.invoice.status, 'paid')
+
+    def test_invalid_payment_method_400(self):
+        self.auth(self.landlord_token)
+        response = self.client.post(
+            reverse('invoice-payments', args=[self.invoice.id]),
+            {'amount': '1000.00', 'payment_method': 'bitcoin'},
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data['payment_method'], ['Invalid choice.'])
+
+    def test_negative_fee_amount_400(self):
+        self.auth(self.landlord_token)
+        response = self.client.post(
+            reverse('invoice-payments', args=[self.invoice.id]),
+            {'amount': '1000.00', 'fee_amount': '-0.01'},
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('fee_amount', response.data)
+
+    def test_malformed_fee_amount_400(self):
+        self.auth(self.landlord_token)
+        response = self.client.post(
+            reverse('invoice-payments', args=[self.invoice.id]),
+            {'amount': '1000.00', 'fee_amount': 'not-a-decimal'},
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('fee_amount', response.data)
+
+    def test_manual_method_surfaces_on_receipt_list_filter(self):
+        self.auth(self.landlord_token)
+        pay_resp = self.client.post(
+            reverse('invoice-payments', args=[self.invoice.id]),
+            {'amount': '45000.00', 'payment_method': 'mpesa', 'transaction_reference': 'MPE-1'},
+        )
+        self.assertEqual(pay_resp.status_code, status.HTTP_201_CREATED)
+        lst = self.client.get(reverse('receipt-list'), {'method': 'mpesa'})
+        self.assertEqual(lst.status_code, status.HTTP_200_OK)
+        self.assertEqual(lst.data['count'], 1)
+        self.assertEqual(lst.data['results'][0]['payment_method'], 'mpesa')
+
 
 class ReceiptTests(APITestCase):
     def setUp(self):
@@ -1473,7 +1578,7 @@ class ReceiptEnrichmentTests(APITestCase):
 
     _EXPECTED_KEYS = frozenset({
         'id', 'payment', 'receipt_number', 'issued_at',
-        'amount', 'payment_status', 'paid_at', 'payment_method',
+        'amount', 'fee_amount', 'payment_status', 'paid_at', 'payment_method',
         'transaction_ref', 'transaction_reference',
         'invoice_id', 'invoice_number', 'invoice_status',
         'invoice_period_start', 'invoice_period_end',
@@ -1518,6 +1623,7 @@ class ReceiptEnrichmentTests(APITestCase):
         self.assertEqual(self._EXPECTED_KEYS, set(response.data.keys()))
         self.assertEqual(response.data['payment'], self.payment.id)
         self.assertEqual(response.data['amount'], '45000.00')
+        self.assertEqual(response.data['fee_amount'], '0.00')
         self.assertEqual(response.data['payment_status'], 'completed')
         self.assertEqual(response.data['payment_method'], 'card')
         self.assertEqual(response.data['transaction_ref'], 'ch_enrich_1')
@@ -1533,6 +1639,14 @@ class ReceiptEnrichmentTests(APITestCase):
         self.assertEqual(response.data['property_id'], self.prop.id)
         self.assertEqual(response.data['property_name'], self.prop.name)
         self.assertEqual(response.data['charge_type'], 'Rent')
+
+    def test_receipt_fee_amount_reflects_payment(self):
+        self.payment.fee_amount = Decimal('12.34')
+        self.payment.save()
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.tenant_token.key}')
+        response = self.client.get(reverse('receipt-detail', args=[self.receipt.id]))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['fee_amount'], '12.34')
 
     def test_transaction_ref_prefers_transaction_reference(self):
         self.payment.transaction_reference = 'TXN-PREF-99'

--- a/billing/views.py
+++ b/billing/views.py
@@ -385,11 +385,29 @@ def pay_invoice(request, pk):
 @extend_schema(
     methods=['POST'],
     summary="Record a manual payment (cash, bank transfer, etc.)",
+    description=(
+        'Body: `amount` (required) must not exceed remaining invoice balance. '
+        '`payment_method` optional — `mpesa`, `bank`, `card`, `cash`, `other` (case-insensitive); '
+        'when omitted, defaults to **`cash`**. '
+        '`fee_amount` optional non-negative decimal — recorded on the payment but **does not** reduce invoice balance '
+        '(only `amount` counts toward paid/partial). '
+        '`transaction_reference` optional — stored on `Payment` and surfaced on receipts.'
+    ),
     examples=[
         OpenApiExample(
-            "Record manual payment",
+            "Record manual payment (amount only)",
             request_only=True,
             value={'amount': '25000.00'},
+        ),
+        OpenApiExample(
+            "Record manual payment (method, fee, reference)",
+            request_only=True,
+            value={
+                'amount': '25000.00',
+                'payment_method': 'mpesa',
+                'fee_amount': '150.00',
+                'transaction_reference': 'QHJ7K2MN01',
+            },
         ),
     ],
 )
@@ -434,13 +452,20 @@ def invoice_payments(request, pk):
             status=status.HTTP_400_BAD_REQUEST,
         )
 
+    pay_method = serializer.validated_data.get('payment_method') or Payment.PAYMENT_METHOD_CASH
+    fee_amt = serializer.validated_data.get('fee_amount', Decimal('0'))
+    tx_ref = serializer.validated_data.get('transaction_reference')
+
     manual_ref = f'manual-{uuid.uuid4().hex}'
     try:
         with transaction.atomic():
             payment = Payment.objects.create(
                 invoice=invoice,
                 amount=amount,
+                fee_amount=fee_amt,
                 stripe_payment_intent_id=manual_ref,
+                payment_method=pay_method,
+                transaction_reference=tx_ref,
                 status='completed',
                 paid_at=timezone.now(),
             )
@@ -692,6 +717,7 @@ def receipt_stats(request):
                         'receipt_number': 'RCP-202604-0001',
                         'issued_at': '2026-04-16T12:00:00Z',
                         'amount': '1500.00',
+                        'fee_amount': '0.00',
                         'payment_status': 'completed',
                         'paid_at': '2026-04-16T11:30:00Z',
                         'payment_method': 'card',
@@ -754,6 +780,7 @@ def receipt_list(request):
                 'receipt_number': 'RCP-202604-0001',
                 'issued_at': '2026-04-16T12:00:00Z',
                 'amount': '1500.00',
+                'fee_amount': '25.00',
                 'payment_status': 'completed',
                 'paid_at': '2026-04-16T11:30:00Z',
                 'payment_method': 'card',

--- a/docs/api-integration.md
+++ b/docs/api-integration.md
@@ -985,26 +985,54 @@ Use when rent was collected **outside Stripe** (cash, M-Pesa, bank transfer, etc
 
 **Who can call:** platform admin, property owner, or agent assigned to the property. The tenant must use `**POST .../pay/`** for Stripe instead.
 
-**Rules:**
+**Request body**
 
-- `amount` is required (decimal string). It must not exceed the **remaining balance** (`total_amount` minus sum of completed payments).
+```json
+{
+  "amount": "25000.00",
+  "payment_method": "mpesa",
+  "fee_amount": "150.00",
+  "transaction_reference": "QHJ7K2MN01"
+}
+```
+
+| Field | Required | Description |
+| ----- | -------- | ----------- |
+| `amount` | **yes** | Decimal string **`≥ 0.01`**. Must not exceed the invoice **remaining balance** (`total_amount` minus sum of completed **`Payment.amount`**). Only this field affects whether the invoice moves to `partial` / `paid` / remaining balance. |
+| `payment_method` | no | How the principal was collected. Allowed values (**case-insensitive**): **`mpesa`**, **`bank`**, **`card`**, **`cash`**, **`other`**. Stored on **`Payment.payment_method`**. If omitted, the API defaults to **`cash`** for manual payments. Invalid value → **400** with `payment_method: ["Invalid choice."]`. On receipts, this field is returned on the enriched row; receipt **list** can filter with `method=`. Receipt **stats** include **`method_breakdown`** (percentages by method) while **`this_month_total`** and **`average_amount`** stay **principal-only** (receipt / payment `amount`, not `fee_amount`). |
+| `fee_amount` | no | Optional decimal string **`≥ 0`** (omit or use **`0.00`** when none). Stored on **`Payment.fee_amount`**. Does **not** reduce invoice principal or remaining balance; invoice math uses **`amount` only**. |
+| `transaction_reference` | no | Optional external reference (M-Pesa code, bank ref, etc.). Stored on **`Payment.transaction_reference`**. Receipts expose the same value as **`transaction_ref`** and **`transaction_reference`** (see Receipts section). |
+
+**Other rules**
+
 - Cannot record on a **cancelled** invoice or when the balance is already **zero**.
 - Multiple POSTs are allowed for **partial** payments until the invoice is fully paid.
 
 ```json
-// Request
+// Request — minimal (method defaults to cash, fee defaults to 0)
 { "amount": "25000.00" }
+
+// Request — full
+{
+  "amount": "25000.00",
+  "payment_method": "mpesa",
+  "fee_amount": "150.00",
+  "transaction_reference": "QHJ7K2MN01"
+}
 ```
 
 ```json
-// Response 201
+// Response 201 — `receipt` uses the same enriched shape as GET /api/billing/receipts/
 {
   "payment": {
     "id": 4,
     "invoice": 1,
     "amount": "25000.00",
+    "fee_amount": "150.00",
     "stripe_payment_intent_id": "manual-abc123...",
     "stripe_charge_id": "",
+    "payment_method": "mpesa",
+    "transaction_reference": "QHJ7K2MN01",
     "status": "completed",
     "paid_at": "2024-02-15T11:00:00Z",
     "created_at": "2024-02-15T11:00:00Z"
@@ -1013,18 +1041,26 @@ Use when rent was collected **outside Stripe** (cash, M-Pesa, bank transfer, etc
     "id": 2,
     "payment": 4,
     "receipt_number": "RCP-202402-0002",
-    "issued_at": "2024-02-15T11:00:00Z"
+    "issued_at": "2024-02-15T11:00:00Z",
+    "amount": "25000.00",
+    "fee_amount": "150.00",
+    "payment_method": "mpesa",
+    "transaction_ref": "QHJ7K2MN01",
+    "transaction_reference": "QHJ7K2MN01",
+    "...": "see Receipts section for full field list"
   }
 }
 ```
 
-
-| Error                         | Status |
-| ----------------------------- | ------ |
-| Tenant or unrelated user      | `403`  |
-| Invoice cancelled             | `400`  |
-| Balance already zero          | `400`  |
-| Amount over remaining balance | `400`  |
+| Error | Status | Notes |
+| ----- | ------ | ----- |
+| Tenant or unrelated user | `403` | |
+| Invoice cancelled | `400` | |
+| Balance already zero | `400` | |
+| `amount` over remaining balance | `400` | |
+| Missing / invalid `amount` (e.g. not a decimal, below `0.01`) | `400` | Field errors under `amount`. |
+| Invalid `payment_method` | `400` | `payment_method: ["Invalid choice."]` |
+| Negative or invalid `fee_amount` | `400` | Field errors under `fee_amount`. |
 
 
 ---
@@ -1096,6 +1132,7 @@ Optional **`property`** (positive integer) and **`month`** (`YYYY-MM`) with the 
   "receipt_number": "RCP-202604-0001",
   "issued_at": "2026-04-16T12:00:00Z",
   "amount": "1500.00",
+  "fee_amount": "0.00",
   "payment_status": "completed",
   "paid_at": "2026-04-16T11:30:00Z",
   "payment_method": "card",
@@ -1120,6 +1157,7 @@ Optional **`property`** (positive integer) and **`month`** (`YYYY-MM`) with the 
 | Field | Notes |
 | ----- | ----- |
 | `payment` | PK of the related `Payment`. |
+| `fee_amount` | Per-payment fee (decimal string); **`0.00`** when none. Not included in invoice balance / receipt stats totals (principal only). |
 | `transaction_ref` / `transaction_reference` | Same resolved value: `transaction_reference` if set, else `stripe_charge_id`, else `null`. Both keys are returned for frontend compatibility. |
 | `charge_type` | **`Rent`** or **`Rent + Service`** if any `AdditionalIncome` exists for the unit on a date within the invoice period. |
 | `payment_status` | `pending`, `completed`, or `failed`. |


### PR DESCRIPTION
Add Payment.fee_amount, extend POST invoice payments payload and validation, receipt serialization, tests, and API docs.

Made-with: Cursor

## Summary by Sourcery

Add support for recording manual payment fees and methods, surfacing them on payments and receipts while keeping invoice balance calculations principal-only.

New Features:
- Allow manual invoice payments to include an optional payment_method, fee_amount, and transaction_reference, defaulting payment_method to cash when omitted.
- Expose fee_amount on Payment and Receipt APIs and enable filtering receipt lists by payment method.
- Extend API documentation to describe manual payment request/response fields and error scenarios, including fee handling and method breakdown behavior.

Enhancements:
- Validate manual payment_method case-insensitively against allowed choices and ensure invalid methods and malformed fee_amounts return 400 errors.
- Ensure per-payment fee_amount is stored without affecting invoice principal, status transitions, or receipt statistics.
- Update serializer, migration, and tests to cover the new Payment.fee_amount field and enriched receipt payload shape.

Documentation:
- Document manual payment payload fields, defaults, and validation rules, including fee_amount semantics and new receipt fee_amount field description in the API integration guide.

Tests:
- Add tests for defaulting and normalizing payment_method, handling optional fee_amount, validation of invalid methods and fee values, and ensuring receipts reflect payment fee_amount and support method filtering.