### PR TITLE
messages upgrade

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ python manage.py test billing
 python manage.py test maintenance
 python manage.py test notifications
 python manage.py test messaging
+python manage.py test messaging.test_api_contract   # messaging JSON schema contracts
 python manage.py test disputes
 python manage.py test moving
 python manage.py test neighborhood
@@ -109,9 +110,14 @@ notifications/      # in-app notification delivery
   migrations/       # 0001 depends on authentication.0007; 0002 adds `payment_reminder` choice
 messaging/          # polling-based user-to-user messaging
   models.py         # Conversation (property FK nullable, subject, created_by), ConversationParticipant (unique: conversation+user), Message (conversation, sender, body)
-  serializers.py    # ConversationSerializer (unread_count, last_message), MessageSerializer (sender_name)
-  views.py          # list/create conversations, detail, list/post messages, mark-read
-  urls.py           # /api/messaging/conversations/
+  serializers.py    # ConversationSerializer (participants, primary_recipient, unread_count, last_message), MessageSerializer, MessagingParticipantLookupSerializer
+  querysets.py      # conversations_queryset_for_user — annotated unread + last message, prefetch participants
+  participant_access.py  # role-safe queryset for GET /api/messaging/participants/ (compose picker)
+  contract_factories.py  # lightweight builders for messaging API contract tests
+  test_api_contract.py   # schema contract tests (list/detail/participants)
+  throttling.py     # MessagingParticipantsThrottle (directory endpoint)
+  views.py          # conversations CRUD, messages, mark-read, participants lookup
+  urls.py           # /api/messaging/participants/, /api/messaging/conversations/, …
   migrations/       # 0001 depends on authentication.0007 + property.0006
 disputes/           # dispute tracking and mediation
   models.py         # Dispute (created_by, property, unit nullable, dispute_type, status, title, description, resolved_by, resolved_at), DisputeMessage (dispute, sender, body)
@@ -281,10 +287,15 @@ any → rejected           (property owner only)
 ### Messaging (`/api/messaging/`)
 | Method | URL | Who |
 |--------|-----|-----|
-| GET/POST | `/api/messaging/conversations/` | Participants only |
+| GET | `/api/messaging/participants/` | Authenticated — role-scoped directory for composing new conversations (`search`, `property`, `limit`; throttled 120/min) |
+| GET/POST | `/api/messaging/conversations/` | List/create — list scoped to participant; create requires `participant_ids` |
 | GET | `/api/messaging/conversations/<pk>/` | Participants only |
 | GET/POST | `/api/messaging/conversations/<pk>/messages/` | Participants only |
 | POST | `/api/messaging/conversations/<pk>/read/` | Participants only |
+
+**Conversation payload (list + detail):** `participants` (each includes `user_id`, legacy `user` same int, `full_name`, `email`, `phone`, `role`, `avatar_url`, `is_self`, `last_read_at`, `joined_at`, plus `username`/`first_name`/`last_name`); `primary_recipient` (user summary or `null` if no other participant); `last_message` (`null` or object with `id`, `sender`, `sender_id`, `sender_username`, `sender_name`, `body`, `created_at`). OpenAPI marks `participants[].user` deprecated — prefer `user_id`.
+
+**Participant directory:** See `messaging/participant_access.py` for role matrix (admin vs landlord/agent/tenant vs artisan/moving company). Optional `property` intersects with owner/agents/active tenants on that property (MovingCompany callers cannot use `property`).
 
 ### Disputes (`/api/disputes/`)
 | Method | URL | Who |
@@ -411,7 +422,7 @@ Any uncaught exception (IntegrityError, etc.) that propagates out of a view duri
 - Each test class has a `setUp` that creates a role, user, and token, and sets client credentials
 - Use `Role.objects.get_or_create(name=role_name)` not `Role.objects.create(name=role_name)` — roles are seeded by data migration 0004 and unique constraint will fail on create
 - Use the `make_user(username, role_name)` helper pattern (see `property/tests.py`) to reduce setUp boilerplate
-- Tests live in the app's `tests.py`
+- Tests live in the app's `tests.py` (messaging also ships `test_api_contract.py` for stable response-shape checks; shared builders in `contract_factories.py`)
 - Permission boundary tests are required — test that the wrong role gets 403, not just that the right role succeeds
 
 ---
@@ -465,7 +476,10 @@ Any uncaught exception (IntegrityError, etc.) that propagates out of a view duri
 ### Messaging
 - Conversations are identified by `property` + `subject` — no deduplication enforced, clients should check before creating
 - `last_read_at` on `ConversationParticipant` is updated via `POST /api/messaging/conversations/<pk>/read/`
-- `unread_count` on `ConversationSerializer` is computed dynamically: messages after `last_read_at`
+- List/detail use `conversations_queryset_for_user` — SQL annotations for `unread_count` and `last_message` (no N+1 on participants; prefetch `user` + `role`)
+- `primary_recipient`: first other participant by participant row id; `null` when viewer is the only participant
+- API contract tests: `python manage.py test messaging.test_api_contract`
+- Participant directory (`GET /api/messaging/participants/`): eligibility enforced in queryset layer in `participant_access.py`, not serializer-only
 
 ### Disputes
 - `dispute_type` choices: `rent`, `maintenance`, `noise`, `damage`, `lease`, `other`

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A property management REST API built with Django. Handles the full lifecycle of 
 | `billing` | Invoices, Stripe payments, receipts, expenses, and financial reports |
 | `maintenance` | Maintenance requests with artisan bidding |
 | `notifications` | In-app notifications and email preferences |
-| `messaging` | Polling-based conversations between users |
+| `messaging` | Polling-based conversations; role-scoped participant directory for compose (`GET /api/messaging/participants/`) |
 | `disputes` | Dispute tracking with a mediation workflow |
 | `moving` | Moving company directory, bookings, and reviews |
 | `neighborhood` | Neighborhood insights (schools, transit, safety) per property |
@@ -95,6 +95,7 @@ python manage.py test billing
 python manage.py test maintenance
 python manage.py test notifications
 python manage.py test messaging
+python manage.py test messaging.test_api_contract  # messaging API JSON schema contracts
 python manage.py test disputes
 python manage.py test moving
 python manage.py test neighborhood

--- a/docs/api-integration.md
+++ b/docs/api-integration.md
@@ -2073,9 +2073,76 @@ No body. Returns `200 { "status": "ok" }`.
 
 Polling-based messaging between users. Conversations can optionally be tied to a property.
 
+### Participant directory (compose / picker)
+
+`GET /api/messaging/participants/`
+
+Authenticated users only. Returns only users the caller is **allowed to message** (enforced in the queryset; see server `messaging/participant_access.py` for the role matrix: admin, landlord, agent, tenant, artisan, moving company).
+
+**Query params**
+
+| Param | Description |
+|-------|-------------|
+| `search` | Optional. Case-insensitive match on username, name parts, email, phone. |
+| `property` | Optional int. Restrict to owner + appointed agents + active tenants on that property. Caller must have access to the property. **Not allowed** for MovingCompany role (`400`). |
+| `limit` | Optional. Default `20`, max `100`. |
+
+**Response** `200`
+
+```json
+{
+  "results": [
+    {
+      "user_id": 3,
+      "full_name": "Jane Doe",
+      "email": "jane@example.com",
+      "phone": "+1555000100",
+      "role": "Tenant",
+      "avatar_url": null,
+      "is_active": true
+    }
+  ]
+}
+```
+
+Rate limit: **120 requests/minute** per user (HTTP 429 when exceeded).
+
+---
+
 ### List Your Conversations
 
 `GET /api/messaging/conversations/`
+
+Returns an array of conversation objects (same shape as detail).
+
+**Participant object** (each element of `participants`):
+
+| Field | Type | Notes |
+|-------|------|--------|
+| `id` | int | ConversationParticipant row id |
+| `user_id` | int | **Canonical** user id — use this in new code |
+| `user` | int | **Deprecated** in OpenAPI — same value as `user_id` (legacy alias) |
+| `username`, `first_name`, `last_name` | string | Legacy / display |
+| `full_name` | string | Display name |
+| `email`, `phone` | string | May be empty |
+| `role` | string | Role name, e.g. `Tenant` |
+| `avatar_url` | null | Reserved for future avatars |
+| `is_self` | bool | `true` when this row is the current user |
+| `last_read_at`, `joined_at` | string (ISO 8601) or null | |
+
+**`primary_recipient`:** User-centric summary for the default “other person” in the thread (first other participant by participant id), or `null` if there is no other participant.
+
+**`last_message`:** `null` if there are no messages; otherwise:
+
+| Field | Type |
+|-------|------|
+| `id` | int |
+| `sender` | int (user id) |
+| `sender_id` | int (same as `sender`) |
+| `sender_username` | string |
+| `sender_name` | string |
+| `body` | string |
+| `created_at` | string (ISO 8601) |
 
 ```json
 [
@@ -2086,20 +2153,62 @@ Polling-based messaging between users. Conversations can optionally be tied to a
     "created_by": 5,
     "created_at": "2024-03-01T09:00:00Z",
     "participants": [
-      { "id": 1, "conversation": 1, "user": 5, "last_read_at": "2024-03-02T08:00:00Z", "joined_at": "2024-03-01T09:00:00Z" },
-      { "id": 2, "conversation": 1, "user": 3, "last_read_at": null, "joined_at": "2024-03-01T09:00:00Z" }
+      {
+        "id": 1,
+        "user_id": 5,
+        "user": 5,
+        "username": "landlord1",
+        "first_name": "Jane",
+        "last_name": "Doe",
+        "full_name": "Jane Doe",
+        "email": "jane@example.com",
+        "phone": "",
+        "role": "Landlord",
+        "avatar_url": null,
+        "is_self": true,
+        "last_read_at": "2024-03-02T08:00:00Z",
+        "joined_at": "2024-03-01T09:00:00Z"
+      },
+      {
+        "id": 2,
+        "user_id": 3,
+        "user": 3,
+        "username": "tenant1",
+        "first_name": "Sam",
+        "last_name": "Renter",
+        "full_name": "Sam Renter",
+        "email": "sam@example.com",
+        "phone": "+1555000200",
+        "role": "Tenant",
+        "avatar_url": null,
+        "is_self": false,
+        "last_read_at": null,
+        "joined_at": "2024-03-01T09:00:00Z"
+      }
     ],
+    "primary_recipient": {
+      "user_id": 3,
+      "full_name": "Sam Renter",
+      "email": "sam@example.com",
+      "phone": "+1555000200",
+      "role": "Tenant",
+      "avatar_url": null
+    },
     "unread_count": 2,
     "last_message": {
       "id": 5,
-      "sender": 5,
-      "sender_name": "Jane Doe",
+      "sender": 3,
+      "sender_id": 3,
+      "sender_username": "tenant1",
+      "sender_name": "Sam Renter",
       "body": "Is the unit still available?",
       "created_at": "2024-03-02T10:00:00Z"
     }
   }
 ]
 ```
+
+**Frontend migration:** Prefer `user_id` everywhere; `user` remains for backward compatibility and is marked deprecated in `/api/docs/`.
 
 ### Start a Conversation
 
@@ -2118,6 +2227,8 @@ Polling-based messaging between users. Conversations can optionally be tied to a
 ### Get a Conversation
 
 `GET /api/messaging/conversations/<pk>/`
+
+Same JSON shape as each element of the list response.
 
 ### List Messages
 

--- a/messaging/contract_factories.py
+++ b/messaging/contract_factories.py
@@ -1,0 +1,43 @@
+"""
+Minimal object builders for messaging API contract tests.
+
+Keeps tests fast: no factory_boy; reuse the same users/graph via setUpTestData.
+"""
+from rest_framework.authtoken.models import Token
+
+from authentication.models import CustomUser, Role
+
+from .models import Conversation, ConversationParticipant, Message
+
+
+def contract_make_user(username: str, role_name: str, *, password: str = 'contract-pass'):
+    role, _ = Role.objects.get_or_create(name=role_name)
+    user = CustomUser.objects.create_user(
+        username=username,
+        password=password,
+        role=role,
+    )
+    token = Token.objects.create(user=user)
+    return user, token
+
+
+def contract_conversation_with_participants(
+    creator,
+    *other_users,
+    subject: str = 'Contract conversation',
+    message_body: str | None = 'Contract message body',
+    message_sender=None,
+):
+    """
+    Create a conversation with creator + other_users as participants.
+    If message_body is not None, creates one message from message_sender (default: first other).
+    """
+    conv = Conversation.objects.create(subject=subject, created_by=creator)
+    ConversationParticipant.objects.create(conversation=conv, user=creator)
+    for u in other_users:
+        ConversationParticipant.objects.create(conversation=conv, user=u)
+    msg = None
+    if message_body is not None:
+        sender = message_sender or other_users[0]
+        msg = Message.objects.create(conversation=conv, sender=sender, body=message_body)
+    return conv, msg

--- a/messaging/participant_access.py
+++ b/messaging/participant_access.py
@@ -1,0 +1,206 @@
+"""
+Role-safe queryset for "who can I start a conversation with?"
+
+Permission matrix (queryset layer — only these users are ever returned):
+
+| Viewer role    | Eligible recipients (always excludes self) |
+|----------------|--------------------------------------------|
+| Admin / staff  | All users (broader directory).             |
+| Landlord       | Active tenants on non-deleted units of    |
+|                | non-deleted properties they own; agents    |
+|                | appointed on those properties.             |
+| Agent          | Property owners, other agents on the same  |
+|                | managed properties, active tenants on      |
+|                | units under those properties.              |
+| Tenant         | Owners and appointed agents for           |
+|                | properties where the tenant has an active  |
+|                | lease (non-deleted unit); moving company   |
+|                | users the tenant has a booking with.       |
+| Artisan        | Submitters and property owners for         |
+|                | maintenance requests the artisan is        |
+|                | assigned to or has placed a bid on.        |
+| MovingCompany  | Customers who booked this company; for     |
+|                | customers, the moving company user on      |
+|                | their bookings.                            |
+| Other / none   | Empty queryset.                            |
+
+Optional `property` query param:
+  Intersects the above with {owner + appointed agents + active tenants on that
+  property's units}. Viewer must have access to that property (same rules as
+  property APIs: owner, appointed agent, active tenant on the property, admin,
+  or artisan with maintenance activity on that property). MovingCompany users
+  cannot scope by property (400).
+
+Search uses case-insensitive substring match on username, first_name,
+last_name, email, phone, and "first last" concatenation. Leading-wildcard
+LIKE cannot use B-tree indexes; consider pg_trgm or dedicated search if this
+becomes hot.
+"""
+from django.db.models import Q, QuerySet
+
+from authentication.models import CustomUser, Role
+from maintenance.models import MaintenanceRequest
+from moving.models import MovingBooking
+from property.models import Lease, Property, PropertyAgent
+
+
+def _is_admin(user) -> bool:
+    return user.is_staff or (
+        getattr(user, 'role', None) is not None and user.role.name == Role.ADMIN
+    )
+
+
+def _active_lease_filter():
+    return Q(is_active=True) & Q(unit__deleted_at__isnull=True)
+
+
+def messaging_participants_base_queryset(viewer: CustomUser) -> QuerySet:
+    """
+    Users the viewer may invite when composing a new conversation.
+    Excludes `viewer` from the queryset.
+    """
+    base = CustomUser.objects.exclude(pk=viewer.pk).select_related('role')
+
+    if _is_admin(viewer):
+        return base
+
+    if not getattr(viewer, 'role_id', None):
+        return base.none()
+
+    role_name = viewer.role.name
+
+    if role_name == Role.LANDLORD:
+        tenant_ids = (
+            Lease.objects.filter(
+                unit__property__owner=viewer,
+                unit__property__deleted_at__isnull=True,
+            )
+            .filter(_active_lease_filter())
+            .values('tenant_id')
+        )
+        agent_ids = PropertyAgent.objects.filter(
+            property__owner=viewer,
+            property__deleted_at__isnull=True,
+        ).values('agent_id')
+        return base.filter(Q(pk__in=tenant_ids) | Q(pk__in=agent_ids))
+
+    if role_name == Role.AGENT:
+        prop_ids = PropertyAgent.objects.filter(agent=viewer).values('property_id')
+        tenant_ids = (
+            Lease.objects.filter(
+                unit__property_id__in=prop_ids,
+                unit__property__deleted_at__isnull=True,
+            )
+            .filter(_active_lease_filter())
+            .values('tenant_id')
+        )
+        owner_ids = Property.objects.filter(
+            pk__in=prop_ids,
+            deleted_at__isnull=True,
+        ).values('owner_id')
+        other_agent_ids = PropertyAgent.objects.filter(
+            property_id__in=prop_ids,
+        ).exclude(agent=viewer).values('agent_id')
+        return base.filter(
+            Q(pk__in=tenant_ids) | Q(pk__in=owner_ids) | Q(pk__in=other_agent_ids)
+        )
+
+    if role_name == Role.TENANT:
+        prop_ids = (
+            Lease.objects.filter(
+                tenant=viewer,
+                unit__property__deleted_at__isnull=True,
+            )
+            .filter(_active_lease_filter())
+            .values('unit__property_id')
+        )
+        owner_ids = Property.objects.filter(
+            pk__in=prop_ids,
+            deleted_at__isnull=True,
+        ).values('owner_id')
+        agent_ids = PropertyAgent.objects.filter(property_id__in=prop_ids).values(
+            'agent_id'
+        )
+        mover_user_ids = MovingBooking.objects.filter(customer=viewer).values(
+            'company__user_id'
+        )
+        return base.filter(
+            Q(pk__in=owner_ids) | Q(pk__in=agent_ids) | Q(pk__in=mover_user_ids)
+        )
+
+    if role_name == Role.ARTISAN:
+        involved = MaintenanceRequest.objects.filter(
+            Q(assigned_to=viewer) | Q(bids__artisan=viewer)
+        ).distinct()
+        submitter_ids = involved.values('submitted_by_id')
+        owner_ids = involved.values('property__owner_id')
+        return base.filter(Q(pk__in=submitter_ids) | Q(pk__in=owner_ids))
+
+    if role_name == Role.MOVING_COMPANY:
+        as_company = MovingBooking.objects.filter(company__user=viewer).values(
+            'customer_id'
+        )
+        as_customer = MovingBooking.objects.filter(customer=viewer).values(
+            'company__user_id'
+        )
+        return base.filter(Q(pk__in=as_company) | Q(pk__in=as_customer))
+
+    return base.none()
+
+
+def viewer_may_filter_by_property(viewer: CustomUser, prop: Property) -> bool:
+    if prop.deleted_at is not None:
+        return False
+    if _is_admin(viewer):
+        return True
+    if not getattr(viewer, 'role_id', None):
+        return False
+    name = viewer.role.name
+    if name == Role.LANDLORD and prop.owner_id == viewer.pk:
+        return True
+    if name == Role.AGENT:
+        return PropertyAgent.objects.filter(property=prop, agent=viewer).exists()
+    if name == Role.TENANT:
+        return Lease.objects.filter(
+            tenant=viewer,
+            unit__property=prop,
+        ).filter(_active_lease_filter()).exists()
+    if name == Role.ARTISAN:
+        return MaintenanceRequest.objects.filter(
+            property=prop,
+        ).filter(Q(assigned_to=viewer) | Q(bids__artisan=viewer)).exists()
+    return False
+
+
+def property_directory_user_id_list(prop: Property) -> list:
+    """Primary keys for owner, appointed agents, and active tenants on `prop`."""
+    if prop.deleted_at is not None:
+        return []
+    ids = {prop.owner_id}
+    ids.update(
+        PropertyAgent.objects.filter(property=prop).values_list('agent_id', flat=True)
+    )
+    ids.update(
+        Lease.objects.filter(unit__property=prop)
+        .filter(_active_lease_filter())
+        .values_list('tenant_id', flat=True)
+    )
+    return [i for i in ids if i is not None]
+
+
+def apply_search(qs: QuerySet, search: str) -> QuerySet:
+    """Search name/email/phone; supports two-token first+last heuristic."""
+    term = (search or '').strip()
+    if not term:
+        return qs
+    parts = term.split()
+    q = (
+        Q(username__icontains=term)
+        | Q(first_name__icontains=term)
+        | Q(last_name__icontains=term)
+        | Q(email__icontains=term)
+        | Q(phone__icontains=term)
+    )
+    if len(parts) >= 2:
+        q |= Q(first_name__icontains=parts[0]) & Q(last_name__icontains=parts[-1])
+    return qs.filter(q)

--- a/messaging/querysets.py
+++ b/messaging/querysets.py
@@ -1,0 +1,99 @@
+"""
+Optimized Conversation querysets for list/detail/create responses.
+
+Migration notes (FE):
+- Prefer participants[].user_id and last_message.sender (user pk) + sender_name.
+- participants[].user mirrors user_id for legacy clients (previously inconsistent).
+- last_message.sender is the sender's user id (aligned with GET .../messages/ rows).
+- last_message.sender_username holds the old string that used to live under sender.
+"""
+from django.db.models import (
+    CharField,
+    Count,
+    DateTimeField,
+    F,
+    OuterRef,
+    Prefetch,
+    Q,
+    Subquery,
+    Value,
+)
+from django.db.models.functions import Coalesce, Concat, NullIf, Trim
+
+from .models import Conversation, ConversationParticipant, Message
+
+
+def conversations_queryset_for_user(user):
+    """
+    Single-query friendly Conversation queryset: unread_count and last_message
+    fields are annotated; participants are prefetched with user + role.
+    """
+    user_last_read = Subquery(
+        ConversationParticipant.objects.filter(
+            conversation_id=OuterRef('pk'),
+            user_id=user.pk,
+        ).values('last_read_at')[:1]
+    )
+
+    latest_base = Message.objects.filter(conversation_id=OuterRef('pk')).order_by('-created_at')
+
+    qs = (
+        Conversation.objects.filter(participants__user=user)
+        .select_related('created_by', 'created_by__role', 'property')
+        .prefetch_related(
+            Prefetch(
+                'participants',
+                queryset=ConversationParticipant.objects.select_related(
+                    'user', 'user__role'
+                ).order_by('id'),
+            ),
+        )
+        .distinct()
+        .annotate(_user_last_read=user_last_read)
+        .annotate(
+            _unread_count=Count(
+                'messages',
+                filter=Q(messages__created_at__gt=F('_user_last_read'))
+                | Q(_user_last_read__isnull=True),
+            )
+        )
+        .annotate(
+            _lm_id=Subquery(latest_base.values('id')[:1]),
+            _lm_body=Subquery(latest_base.values('body')[:1]),
+            _lm_created_at=Subquery(latest_base.values('created_at')[:1]),
+            _lm_sender_id=Subquery(latest_base.values('sender_id')[:1]),
+            _lm_sender_username=Subquery(
+                latest_base.values('sender__username')[:1], output_field=CharField()
+            ),
+            _lm_sender_name=Subquery(
+                Message.objects.filter(conversation_id=OuterRef('pk'))
+                .order_by('-created_at')
+                .annotate(
+                    _sn=Coalesce(
+                        NullIf(
+                            Trim(
+                                Concat(
+                                    F('sender__first_name'),
+                                    Value(' '),
+                                    F('sender__last_name'),
+                                )
+                            ),
+                            Value(''),
+                        ),
+                        F('sender__username'),
+                    )
+                )
+                .values('_sn')[:1],
+                output_field=CharField(),
+            ),
+        )
+    )
+    qs = qs.annotate(
+        _sort_ts=Coalesce(F('_lm_created_at'), F('created_at'), output_field=DateTimeField()),
+    )
+    return qs.order_by(F('_sort_ts').desc(nulls_last=True), '-id')
+
+
+def get_conversation_for_user(*, user, pk):
+    """Fetch one conversation with the same annotations/prefetch as list."""
+    return conversations_queryset_for_user(user).get(pk=pk)

--- a/messaging/serializers.py
+++ b/messaging/serializers.py
@@ -1,44 +1,249 @@
-from rest_framework import serializers
+"""
+Messaging serializers.
 
+Frontend deprecation (participants on conversation payloads):
+- **Now–Q4 2026:** `participants[].user` remains populated (same int as `user_id`); OpenAPI marks it deprecated.
+- **Target removal (not before 2027-01):** drop `user` once all clients use `user_id`; coordinate with mobile/web release train.
+"""
+from rest_framework import serializers
+from drf_spectacular.utils import OpenApiExample, extend_schema_serializer
+
+from authentication.models import CustomUser
 from .models import Conversation, ConversationParticipant, Message
 
 
+def _user_role_name(user):
+    if not user.role_id:
+        return None
+    role = user.role
+    if role is None:
+        return None
+    return role.name
+
+
+def primary_recipient_blob(user):
+    """User-centric display payload for primary_recipient (no participant row id)."""
+    return {
+        'user_id': user.id,
+        'full_name': user.get_full_name().strip() or user.username,
+        'email': user.email or '',
+        'phone': user.phone or '',
+        'role': _user_role_name(user),
+        'avatar_url': None,
+    }
+
+
+@extend_schema_serializer(
+    examples=[
+        OpenApiExample(
+            'Participant directory row',
+            value={
+                'user_id': 42,
+                'full_name': 'Sam Tenant',
+                'email': 'sam@example.com',
+                'phone': '+1555000100',
+                'role': 'Tenant',
+                'avatar_url': None,
+                'is_active': True,
+            },
+            response_only=True,
+        ),
+    ],
+)
+class MessagingParticipantLookupSerializer(serializers.ModelSerializer):
+    """Row for GET /api/messaging/participants/ (compose conversation picker)."""
+
+    user_id = serializers.IntegerField(source='id', read_only=True)
+    full_name = serializers.SerializerMethodField()
+    role = serializers.SerializerMethodField()
+    avatar_url = serializers.SerializerMethodField()
+
+    class Meta:
+        model = CustomUser
+        fields = [
+            'user_id',
+            'full_name',
+            'email',
+            'phone',
+            'role',
+            'avatar_url',
+            'is_active',
+        ]
+
+    def get_full_name(self, obj):
+        return obj.get_full_name().strip() or obj.username
+
+    def get_role(self, obj):
+        return _user_role_name(obj)
+
+    def get_avatar_url(self, obj):
+        return None
+
+
+@extend_schema_serializer(
+    deprecate_fields=('user',),
+    examples=[
+        OpenApiExample(
+            'Conversation participant',
+            value={
+                'id': 9,
+                'user_id': 42,
+                'user': 42,
+                'username': 'sam_t',
+                'first_name': 'Sam',
+                'last_name': 'Tenant',
+                'full_name': 'Sam Tenant',
+                'email': 'sam@example.com',
+                'phone': '+1555000100',
+                'role': 'Tenant',
+                'avatar_url': None,
+                'is_self': False,
+                'last_read_at': None,
+                'joined_at': '2026-04-17T12:00:00Z',
+            },
+            response_only=True,
+        ),
+    ],
+)
 class ConversationParticipantSerializer(serializers.ModelSerializer):
+    """
+    Participant row + normalized user identity for FE.
+
+    OpenAPI: ``user`` is deprecated (alias of ``user_id``); new clients should use ``user_id`` only.
+    """
     user_id = serializers.IntegerField(source='user.id', read_only=True)
+    user = serializers.IntegerField(
+        source='user.id',
+        read_only=True,
+        help_text='Deprecated: same integer as user_id. Prefer user_id.',
+    )
     username = serializers.CharField(source='user.username', read_only=True)
     first_name = serializers.CharField(source='user.first_name', read_only=True)
     last_name = serializers.CharField(source='user.last_name', read_only=True)
+    full_name = serializers.SerializerMethodField()
+    email = serializers.SerializerMethodField()
+    phone = serializers.SerializerMethodField()
+    role = serializers.SerializerMethodField()
+    avatar_url = serializers.SerializerMethodField()
+    is_self = serializers.SerializerMethodField()
 
     class Meta:
         model = ConversationParticipant
-        fields = ['id', 'user_id', 'username', 'first_name', 'last_name', 'last_read_at', 'joined_at']
+        fields = [
+            'id',
+            'user_id',
+            'user',
+            'username',
+            'first_name',
+            'last_name',
+            'full_name',
+            'email',
+            'phone',
+            'role',
+            'avatar_url',
+            'is_self',
+            'last_read_at',
+            'joined_at',
+        ]
+
+    def get_full_name(self, obj):
+        u = obj.user
+        return u.get_full_name().strip() or u.username
+
+    def get_email(self, obj):
+        return obj.user.email or ''
+
+    def get_phone(self, obj):
+        return obj.user.phone or ''
+
+    def get_role(self, obj):
+        return _user_role_name(obj.user)
+
+    def get_avatar_url(self, obj):
+        return None
+
+    def get_is_self(self, obj):
+        request = self.context.get('request')
+        if not request or not request.user.is_authenticated:
+            return False
+        return obj.user_id == request.user.id
 
 
-class MessageSerializer(serializers.ModelSerializer):
-    sender_name = serializers.SerializerMethodField()
-
-    class Meta:
-        model = Message
-        fields = ['id', 'conversation', 'sender', 'sender_name', 'body', 'created_at']
-        read_only_fields = ['id', 'conversation', 'sender', 'created_at']
-
-    def get_sender_name(self, obj):
-        return f"{obj.sender.first_name} {obj.sender.last_name}".strip() or obj.sender.username
-
-
+@extend_schema_serializer(
+    examples=[
+        OpenApiExample(
+            'Conversation with last_message',
+            value={
+                'id': 1,
+                'property': None,
+                'subject': 'Maintenance follow-up',
+                'created_by': 10,
+                'created_at': '2026-04-17T12:00:00Z',
+                'participants': [],
+                'primary_recipient': {
+                    'user_id': 11,
+                    'full_name': 'Sam Tenant',
+                    'email': 'sam@example.com',
+                    'phone': '',
+                    'role': 'Tenant',
+                    'avatar_url': None,
+                },
+                'unread_count': 0,
+                'last_message': {
+                    'id': 99,
+                    'sender': 11,
+                    'sender_id': 11,
+                    'sender_username': 'sam_t',
+                    'sender_name': 'Sam Tenant',
+                    'body': 'Thanks!',
+                    'created_at': '2026-04-17T12:05:00Z',
+                },
+            },
+            response_only=True,
+        ),
+    ],
+)
 class ConversationSerializer(serializers.ModelSerializer):
     participants = ConversationParticipantSerializer(many=True, read_only=True)
+    primary_recipient = serializers.SerializerMethodField(
+        help_text='First other participant (by participant row id); null if none.',
+    )
     unread_count = serializers.SerializerMethodField()
-    last_message = serializers.SerializerMethodField()
+    last_message = serializers.SerializerMethodField(
+        help_text='Latest message summary; null if no messages. When set, includes sender, sender_name, body, created_at.',
+    )
 
     class Meta:
         model = Conversation
-        fields = ['id', 'property', 'subject', 'created_by', 'created_at', 'participants', 'unread_count', 'last_message']
+        fields = [
+            'id',
+            'property',
+            'subject',
+            'created_by',
+            'created_at',
+            'participants',
+            'primary_recipient',
+            'unread_count',
+            'last_message',
+        ]
         read_only_fields = ['id', 'created_by', 'created_at']
 
-    def get_unread_count(self, obj):
+    def get_primary_recipient(self, obj):
         request = self.context.get('request')
-        if not request:
+        if not request or not request.user.is_authenticated:
+            return None
+        # Prefetch uses order_by('id') for deterministic "first other" in group chats.
+        for p in obj.participants.all():
+            if p.user_id != request.user.id:
+                return primary_recipient_blob(p.user)
+        return None
+
+    def get_unread_count(self, obj):
+        annotated = getattr(obj, '_unread_count', None)
+        if annotated is not None:
+            return annotated
+        request = self.context.get('request')
+        if not request or not request.user.is_authenticated:
             return 0
         user = request.user
         try:
@@ -51,12 +256,45 @@ class ConversationSerializer(serializers.ModelSerializer):
         return obj.messages.filter(created_at__gt=last_read).count()
 
     def get_last_message(self, obj):
-        last = obj.messages.order_by('-created_at').first()
+        lm_id = getattr(obj, '_lm_id', None)
+        if lm_id is not None:
+            sender_id = getattr(obj, '_lm_sender_id', None)
+            sender_name = getattr(obj, '_lm_sender_name', None) or ''
+            sender_username = getattr(obj, '_lm_sender_username', None) or ''
+            return {
+                'id': lm_id,
+                'sender': sender_id,
+                'sender_id': sender_id,
+                'sender_username': sender_username,
+                'sender_name': sender_name,
+                'body': getattr(obj, '_lm_body', None),
+                'created_at': getattr(obj, '_lm_created_at', None),
+            }
+        last = obj.messages.order_by('-created_at').select_related('sender').first()
         if last is None:
             return None
+        sender_name = (
+            f'{last.sender.first_name} {last.sender.last_name}'.strip()
+            or last.sender.username
+        )
         return {
             'id': last.id,
+            'sender': last.sender_id,
+            'sender_id': last.sender_id,
+            'sender_username': last.sender.username,
+            'sender_name': sender_name,
             'body': last.body,
-            'sender': last.sender.username,
             'created_at': last.created_at,
         }
+
+
+class MessageSerializer(serializers.ModelSerializer):
+    sender_name = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Message
+        fields = ['id', 'conversation', 'sender', 'sender_name', 'body', 'created_at']
+        read_only_fields = ['id', 'conversation', 'sender', 'created_at']
+
+    def get_sender_name(self, obj):
+        return f"{obj.sender.first_name} {obj.sender.last_name}".strip() or obj.sender.username

--- a/messaging/test_api_contract.py
+++ b/messaging/test_api_contract.py
@@ -1,0 +1,249 @@
+"""
+API contract tests: stable JSON shape for messaging list/detail and participant directory.
+
+Sample list row (landlord viewing a 1:1 thread with a tenant who sent the last message):
+
+{
+  "id": 1,
+  "property": null,
+  "subject": "Contract conversation",
+  "created_by": 10,
+  "created_at": "2026-04-17T12:00:00Z",
+  "participants": [
+    {
+      "id": 1,
+      "user_id": 10,
+      "user": 10,
+      "username": "contract_ll",
+      "first_name": "",
+      "last_name": "",
+      "full_name": "contract_ll",
+      "email": "",
+      "phone": "",
+      "role": "Landlord",
+      "avatar_url": null,
+      "is_self": true,
+      "last_read_at": null,
+      "joined_at": "2026-04-17T12:00:00Z"
+    },
+    {
+      "id": 2,
+      "user_id": 11,
+      "user": 11,
+      "username": "contract_tt",
+      ...
+      "is_self": false,
+      ...
+    }
+  ],
+  "primary_recipient": {
+    "user_id": 11,
+    "full_name": "contract_tt",
+    "email": "",
+    "phone": "",
+    "role": "Tenant",
+    "avatar_url": null
+  },
+  "unread_count": 0,
+  "last_message": {
+    "id": 1,
+    "sender": 11,
+    "sender_id": 11,
+    "sender_username": "contract_tt",
+    "sender_name": "contract_tt",
+    "body": "Contract message body",
+    "created_at": "2026-04-17T12:00:01Z"
+  }
+}
+
+Sample GET /api/messaging/participants/ row:
+
+{
+  "user_id": 11,
+  "full_name": "contract_tt",
+  "email": "t@contract.test",
+  "phone": "",
+  "role": "Tenant",
+  "avatar_url": null,
+  "is_active": true
+}
+"""
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+from datetime import date
+
+from authentication.models import Role
+from property.models import Lease, Property, Unit
+
+from .contract_factories import contract_conversation_with_participants, contract_make_user
+from .models import Conversation, ConversationParticipant
+
+
+PARTICIPANT_STABLE_KEYS = frozenset({
+    'id',
+    'user_id',
+    'user',
+    'username',
+    'first_name',
+    'last_name',
+    'full_name',
+    'email',
+    'phone',
+    'role',
+    'avatar_url',
+    'is_self',
+    'last_read_at',
+    'joined_at',
+})
+
+PRIMARY_RECIPIENT_KEYS = frozenset({
+    'user_id', 'full_name', 'email', 'phone', 'role', 'avatar_url',
+})
+
+LAST_MESSAGE_KEYS = frozenset({
+    'id',
+    'sender',
+    'sender_id',
+    'sender_username',
+    'sender_name',
+    'body',
+    'created_at',
+})
+
+
+def _assert_participant_contract(testcase, p: dict, viewer_id: int):
+    missing = PARTICIPANT_STABLE_KEYS - set(p.keys())
+    testcase.assertFalse(missing, f'participant missing keys: {sorted(missing)}')
+    testcase.assertIsInstance(p['user_id'], int)
+    testcase.assertIsInstance(p['user'], int)
+    testcase.assertEqual(p['user_id'], p['user'], 'legacy user must mirror user_id')
+    testcase.assertIsInstance(p['is_self'], bool)
+    testcase.assertEqual(p['is_self'], p['user_id'] == viewer_id)
+
+
+def _assert_last_message_contract(testcase, lm: dict):
+    missing = LAST_MESSAGE_KEYS - set(lm.keys())
+    testcase.assertFalse(missing, f'last_message missing keys: {sorted(missing)}')
+    testcase.assertIsNotNone(lm['sender'])
+    testcase.assertIsInstance(lm['sender'], int)
+    testcase.assertIsNotNone(lm['sender_name'])
+    testcase.assertIsInstance(lm['sender_name'], str)
+
+
+class MessagingConversationApiContractTests(APITestCase):
+    """Contract for GET /api/messaging/conversations/ and GET .../{id}/."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.landlord, cls.landlord_token = contract_make_user('contract_ll', Role.LANDLORD)
+        cls.tenant, cls.tenant_token = contract_make_user('contract_tt', Role.TENANT)
+        cls.tenant.email = 't@contract.test'
+        cls.tenant.save()
+        cls.conv, cls.msg = contract_conversation_with_participants(
+            cls.landlord,
+            cls.tenant,
+            subject='Contract conversation',
+            message_body='Contract message body',
+            message_sender=cls.tenant,
+        )
+        cls.conv_empty, _ = contract_conversation_with_participants(
+            cls.landlord,
+            cls.tenant,
+            subject='No messages yet',
+            message_body=None,
+        )
+
+    def test_list_conversation_participants_schema(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.landlord_token.key}')
+        response = self.client.get(reverse('conversation-list-create'))
+        self.assertEqual(response.status_code, 200)
+        row = next(r for r in response.data if r['id'] == self.conv.id)
+        self.assertIn('participants', row)
+        self.assertIsInstance(row['participants'], list)
+        self.assertGreaterEqual(len(row['participants']), 2)
+        for p in row['participants']:
+            _assert_participant_contract(self, p, self.landlord.id)
+
+    def test_detail_includes_primary_recipient_object_or_null(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.landlord_token.key}')
+        response = self.client.get(reverse('conversation-detail', args=[self.conv.pk]))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('primary_recipient', response.data)
+        pr = response.data['primary_recipient']
+        self.assertIsNotNone(pr)
+        self.assertEqual(set(pr.keys()), PRIMARY_RECIPIENT_KEYS)
+
+        d2 = self.client.get(reverse('conversation-detail', args=[self.conv_empty.pk]))
+        self.assertEqual(d2.status_code, 200)
+        self.assertIn('primary_recipient', d2.data)
+        self.assertIsNotNone(d2.data['primary_recipient'])
+
+        solo = Conversation.objects.create(subject='solo thread', created_by=self.landlord)
+        ConversationParticipant.objects.create(conversation=solo, user=self.landlord)
+        solo_resp = self.client.get(reverse('conversation-detail', args=[solo.pk]))
+        self.assertEqual(solo_resp.status_code, 200)
+        self.assertIn('primary_recipient', solo_resp.data)
+        self.assertIsNone(solo_resp.data['primary_recipient'])
+
+    def test_last_message_schema_when_non_null(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.landlord_token.key}')
+        response = self.client.get(reverse('conversation-list-create'))
+        self.assertEqual(response.status_code, 200)
+        row = next(r for r in response.data if r['id'] == self.conv.id)
+        self.assertIsNotNone(row['last_message'])
+        _assert_last_message_contract(self, row['last_message'])
+
+        detail = self.client.get(reverse('conversation-detail', args=[self.conv.pk]))
+        self.assertIsNotNone(detail.data['last_message'])
+        _assert_last_message_contract(self, detail.data['last_message'])
+
+    def test_last_message_null_when_no_messages(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.landlord_token.key}')
+        response = self.client.get(reverse('conversation-detail', args=[self.conv_empty.pk]))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('last_message', response.data)
+        self.assertIsNone(response.data['last_message'])
+
+
+class MessagingParticipantsDirectoryContractTests(APITestCase):
+    """Contract: directory endpoint returns only role-allowed users."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.landlord, cls.landlord_token = contract_make_user('dir_ll', Role.LANDLORD)
+        cls.tenant, cls.tenant_token = contract_make_user('dir_tt', Role.TENANT)
+        cls.stranger, _ = contract_make_user('dir_stranger', Role.TENANT)
+        prop = Property.objects.create(
+            name='Dir Prop',
+            property_type='apartment',
+            owner=cls.landlord,
+            created_by=cls.landlord,
+        )
+        unit = Unit.objects.create(
+            property=prop,
+            name='U1',
+            created_by=cls.landlord,
+            is_occupied=True,
+        )
+        Lease.objects.create(
+            unit=unit,
+            tenant=cls.tenant,
+            start_date=date.today(),
+            rent_amount=100,
+            is_active=True,
+        )
+
+    def test_directory_only_returns_allowed_users_for_landlord(self):
+        url = reverse('messaging-participants-lookup')
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.landlord_token.key}')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        ids = {row['user_id'] for row in response.data['results']}
+        self.assertIn(self.tenant.id, ids)
+        self.assertNotIn(self.stranger.id, ids)
+        self.assertNotIn(self.landlord.id, ids)
+        for row in response.data['results']:
+            self.assertIn('user_id', row)
+            self.assertIn('full_name', row)
+            self.assertIn('is_active', row)

--- a/messaging/tests.py
+++ b/messaging/tests.py
@@ -1,8 +1,14 @@
+from datetime import date
+
 from django.urls import reverse
+from django.test.utils import override_settings
 from rest_framework.test import APITestCase
 from rest_framework.authtoken.models import Token
 
-from authentication.models import CustomUser, Role
+from authentication.models import CustomUser, MovingCompanyProfile, Role
+from maintenance.models import MaintenanceBid, MaintenanceRequest
+from moving.models import MovingBooking
+from property.models import Lease, Property, PropertyAgent, Unit
 from .models import Conversation, ConversationParticipant, Message
 
 
@@ -223,3 +229,338 @@ class ConversationMarkReadTests(APITestCase):
         self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.outsider_token.key}')
         response = self.client.post(self._read_url(self.conversation.pk))
         self.assertEqual(response.status_code, 403)
+
+
+class ConversationParticipantPayloadTests(APITestCase):
+    """Schema + primary_recipient + last_message shape; backward-compatible keys."""
+
+    def setUp(self):
+        self.landlord, self.landlord_token = make_user('schema_landlord', Role.LANDLORD)
+        self.tenant_a, self.tenant_a_token = make_user('schema_tenant_a', Role.TENANT)
+        self.tenant_b, self.tenant_b_token = make_user('schema_tenant_b', Role.TENANT)
+
+        self.landlord.email = 'landlord@example.com'
+        self.landlord.phone = '+10001'
+        self.landlord.first_name = 'Lou'
+        self.landlord.last_name = 'Owner'
+        self.landlord.save()
+
+        self.tenant_a.email = 'a@example.com'
+        self.tenant_a.phone = '+10002'
+        self.tenant_a.first_name = 'Ann'
+        self.tenant_a.last_name = 'Tenant'
+        self.tenant_a.save()
+
+        self.tenant_b.first_name = 'Bob'
+        self.tenant_b.last_name = 'Other'
+        self.tenant_b.save()
+
+        self.group_conv = Conversation.objects.create(
+            subject='Group chat',
+            created_by=self.landlord,
+        )
+        ConversationParticipant.objects.create(conversation=self.group_conv, user=self.landlord)
+        ConversationParticipant.objects.create(conversation=self.group_conv, user=self.tenant_a)
+        ConversationParticipant.objects.create(conversation=self.group_conv, user=self.tenant_b)
+
+        Message.objects.create(
+            conversation=self.group_conv,
+            sender=self.tenant_b,
+            body='Hello group',
+        )
+
+    def _assert_participant_shape(self, p, viewer: CustomUser):
+        self.assertIn('id', p)
+        self.assertIn('user_id', p)
+        self.assertIn('user', p)
+        self.assertEqual(p['user_id'], p['user'])
+        self.assertIn('full_name', p)
+        self.assertIn('email', p)
+        self.assertIn('phone', p)
+        self.assertIn('role', p)
+        self.assertIn('avatar_url', p)
+        self.assertIsNone(p['avatar_url'])
+        self.assertIn('is_self', p)
+        self.assertEqual(p['is_self'], p['user_id'] == viewer.id)
+        self.assertIn('last_read_at', p)
+        self.assertIn('joined_at', p)
+        self.assertIn('username', p)
+        self.assertIn('first_name', p)
+        self.assertIn('last_name', p)
+
+    def _assert_last_message_shape(self, lm, expected_sender_id):
+        self.assertIsNotNone(lm)
+        for key in ('id', 'sender', 'sender_name', 'body', 'created_at'):
+            self.assertIn(key, lm)
+        self.assertEqual(lm['sender'], expected_sender_id)
+        self.assertEqual(lm['sender_id'], expected_sender_id)
+        self.assertIn('sender_username', lm)
+
+    def test_list_participants_primary_recipient_and_last_message(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.landlord_token.key}')
+        response = self.client.get(reverse('conversation-list-create'))
+        self.assertEqual(response.status_code, 200)
+        row = next(c for c in response.data if c['id'] == self.group_conv.id)
+
+        self.assertIn('primary_recipient', row)
+        pr = row['primary_recipient']
+        self.assertIsNotNone(pr)
+        self.assertEqual(pr['user_id'], self.tenant_a.id)
+        self.assertEqual(pr['full_name'], 'Ann Tenant')
+        self.assertEqual(pr['email'], 'a@example.com')
+        self.assertEqual(pr['phone'], '+10002')
+        self.assertEqual(pr['role'], Role.TENANT)
+        self.assertIsNone(pr['avatar_url'])
+
+        for p in row['participants']:
+            self._assert_participant_shape(p, self.landlord)
+
+        self._assert_last_message_shape(row['last_message'], self.tenant_b.id)
+        self.assertEqual(row['last_message']['sender_username'], self.tenant_b.username)
+
+    def test_detail_tenant_primary_recipient_is_landlord(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.tenant_a_token.key}')
+        response = self.client.get(reverse('conversation-detail', args=[self.group_conv.pk]))
+        self.assertEqual(response.status_code, 200)
+        pr = response.data['primary_recipient']
+        self.assertIsNotNone(pr)
+        self.assertEqual(pr['user_id'], self.landlord.id)
+        self.assertEqual(pr['full_name'], 'Lou Owner')
+
+    def test_group_chat_primary_recipient_first_non_self_by_participant_id_order(self):
+        """Non-landlord participant: first other by participant pk order is landlord."""
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.tenant_b_token.key}')
+        response = self.client.get(reverse('conversation-detail', args=[self.group_conv.pk]))
+        self.assertEqual(response.status_code, 200)
+        pr = response.data['primary_recipient']
+        self.assertIsNotNone(pr)
+        self.assertEqual(pr['user_id'], self.landlord.id)
+
+    @override_settings(DEBUG=True)
+    def test_list_and_detail_query_count_stays_bounded(self):
+        """List/detail use one annotated conversation query + prefetch; no N+1 on participants."""
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.landlord_token.key}')
+        with self.assertNumQueries(3, using='default'):
+            response = self.client.get(reverse('conversation-list-create'))
+        self.assertEqual(response.status_code, 200)
+        with self.assertNumQueries(3, using='default'):
+            response = self.client.get(reverse('conversation-detail', args=[self.group_conv.pk]))
+        self.assertEqual(response.status_code, 200)
+
+
+class MessagingParticipantsLookupTests(APITestCase):
+    """GET /api/messaging/participants/ — role-scoped compose directory."""
+
+    def setUp(self):
+        self.landlord, self.landlord_token = make_user('mplandlord', Role.LANDLORD)
+        self.agent, self.agent_token = make_user('mpagent', Role.AGENT)
+        self.tenant, self.tenant_token = make_user('mptenant', Role.TENANT)
+        self.stranger, self.stranger_token = make_user('mpstranger', Role.TENANT)
+        self.admin, self.admin_token = make_user('mpadmin', Role.ADMIN)
+        self.admin.is_staff = True
+        self.admin.save()
+
+        self.tenant.email = 'tenant.mail@example.com'
+        self.tenant.phone = '+15550001111'
+        self.tenant.first_name = 'Pat'
+        self.tenant.last_name = 'Leaseholder'
+        self.tenant.save()
+
+        self.prop_a = Property.objects.create(
+            name='Prop A',
+            property_type='apartment',
+            owner=self.landlord,
+            created_by=self.landlord,
+        )
+        self.prop_b = Property.objects.create(
+            name='Prop B',
+            property_type='house',
+            owner=self.landlord,
+            created_by=self.landlord,
+        )
+        self.unit_a = Unit.objects.create(
+            property=self.prop_a,
+            name='A1',
+            created_by=self.landlord,
+            is_occupied=True,
+        )
+        self.unit_b = Unit.objects.create(
+            property=self.prop_b,
+            name='B1',
+            created_by=self.landlord,
+            is_occupied=True,
+        )
+        Lease.objects.create(
+            unit=self.unit_a,
+            tenant=self.tenant,
+            start_date=date.today(),
+            rent_amount=100,
+            is_active=True,
+        )
+        PropertyAgent.objects.create(
+            property=self.prop_a,
+            agent=self.agent,
+            appointed_by=self.landlord,
+        )
+
+        self.artisan, self.artisan_token = make_user('mpartisan', Role.ARTISAN)
+        self.mreq = MaintenanceRequest.objects.create(
+            property=self.prop_a,
+            unit=self.unit_a,
+            submitted_by=self.tenant,
+            title='Tap',
+            description='Drip',
+            category='plumbing',
+        )
+        MaintenanceBid.objects.create(
+            request=self.mreq,
+            artisan=self.artisan,
+            proposed_price=50,
+        )
+
+        self.mover, self.mover_token = make_user('mpmover', Role.MOVING_COMPANY)
+        self.mover_profile = MovingCompanyProfile.objects.create(
+            user=self.mover,
+            company_name='Movers Inc',
+        )
+        MovingBooking.objects.create(
+            company=self.mover_profile,
+            customer=self.tenant,
+            moving_date=date.today(),
+            moving_time='10:00:00',
+            pickup_address='A',
+            delivery_address='B',
+        )
+
+        self.url = reverse('messaging-participants-lookup')
+
+    def _ids(self, response):
+        return {row['user_id'] for row in response.data['results']}
+
+    def test_landlord_sees_tenant_and_agent_not_stranger(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.landlord_token.key}')
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        ids = self._ids(response)
+        self.assertIn(self.tenant.id, ids)
+        self.assertIn(self.agent.id, ids)
+        self.assertNotIn(self.stranger.id, ids)
+        self.assertNotIn(self.landlord.id, ids)
+
+    def test_tenant_sees_landlord_agent_and_moving_company(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.tenant_token.key}')
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        ids = self._ids(response)
+        self.assertIn(self.landlord.id, ids)
+        self.assertIn(self.agent.id, ids)
+        self.assertIn(self.mover.id, ids)
+        self.assertNotIn(self.stranger.id, ids)
+
+    def test_agent_sees_landlord_and_tenant(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.agent_token.key}')
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        ids = self._ids(response)
+        self.assertIn(self.landlord.id, ids)
+        self.assertIn(self.tenant.id, ids)
+
+    def test_admin_includes_unrelated_user(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.admin_token.key}')
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        ids = self._ids(response)
+        self.assertIn(self.stranger.id, ids)
+
+    def test_artisan_sees_submitter_and_owner(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.artisan_token.key}')
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        ids = self._ids(response)
+        self.assertIn(self.tenant.id, ids)
+        self.assertIn(self.landlord.id, ids)
+
+    def test_moving_company_sees_counterparty(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.mover_token.key}')
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        ids = self._ids(response)
+        self.assertIn(self.tenant.id, ids)
+
+    def test_search_email_phone_and_full_name(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.landlord_token.key}')
+        r1 = self.client.get(self.url, {'search': 'tenant.mail@example.com'})
+        self.assertEqual(r1.status_code, 200)
+        self.assertEqual(self._ids(r1), {self.tenant.id})
+
+        r2 = self.client.get(self.url, {'search': '+15550001111'})
+        self.assertEqual(r2.status_code, 200)
+        self.assertEqual(self._ids(r2), {self.tenant.id})
+
+        r3 = self.client.get(self.url, {'search': 'Pat Leaseholder'})
+        self.assertEqual(r3.status_code, 200)
+        self.assertEqual(self._ids(r3), {self.tenant.id})
+
+    def test_property_filter_narrows_to_that_property(self):
+        other_tenant, _ = make_user('mpother_t', Role.TENANT)
+        Lease.objects.create(
+            unit=self.unit_b,
+            tenant=other_tenant,
+            start_date=date.today(),
+            rent_amount=200,
+            is_active=True,
+        )
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.landlord_token.key}')
+        response = self.client.get(self.url, {'property': self.prop_a.id})
+        self.assertEqual(response.status_code, 200)
+        ids = self._ids(response)
+        self.assertIn(self.tenant.id, ids)
+        self.assertIn(self.agent.id, ids)
+        self.assertNotIn(other_tenant.id, ids)
+
+    def test_property_filter_forbidden_for_unrelated_tenant(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.stranger_token.key}')
+        response = self.client.get(self.url, {'property': self.prop_a.id})
+        self.assertEqual(response.status_code, 403)
+
+    def test_moving_company_property_filter_bad_request(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.mover_token.key}')
+        response = self.client.get(self.url, {'property': self.prop_a.id})
+        self.assertEqual(response.status_code, 400)
+
+    def test_invalid_limit_returns_400(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.landlord_token.key}')
+        response = self.client.get(self.url, {'limit': 'x'})
+        self.assertEqual(response.status_code, 400)
+
+    def test_unauthenticated_401(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 401)
+
+    def test_result_row_shape(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.landlord_token.key}')
+        response = self.client.get(self.url, {'search': self.tenant.username})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['results']), 1)
+        row = response.data['results'][0]
+        for key in (
+            'user_id',
+            'full_name',
+            'email',
+            'phone',
+            'role',
+            'avatar_url',
+            'is_active',
+        ):
+            self.assertIn(key, row)
+        self.assertEqual(row['user_id'], self.tenant.id)
+        self.assertIsNone(row['avatar_url'])
+        self.assertEqual(row['role'], Role.TENANT)
+
+    @override_settings(DEBUG=True)
+    def test_lookup_query_count_bounded(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.landlord_token.key}')
+        # Token auth + occasional role fetch + one eligible-users SELECT (select_related role).
+        with self.assertNumQueries(3, using='default'):
+            response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)

--- a/messaging/throttling.py
+++ b/messaging/throttling.py
@@ -1,0 +1,7 @@
+from rest_framework.throttling import UserRateThrottle
+
+
+class MessagingParticipantsThrottle(UserRateThrottle):
+    """Limits abusive directory scraping on GET /api/messaging/participants/."""
+
+    rate = '120/min'

--- a/messaging/urls.py
+++ b/messaging/urls.py
@@ -5,9 +5,11 @@ from .views import (
     conversation_detail,
     message_list_create,
     conversation_mark_read,
+    messaging_participants_lookup,
 )
 
 urlpatterns = [
+    path('participants/', messaging_participants_lookup, name='messaging-participants-lookup'),
     path('conversations/', conversation_list_create, name='conversation-list-create'),
     path('conversations/<int:pk>/', conversation_detail, name='conversation-detail'),
     path('conversations/<int:pk>/messages/', message_list_create, name='message-list-create'),

--- a/messaging/views.py
+++ b/messaging/views.py
@@ -1,14 +1,28 @@
+from django.db.models import Prefetch
 from django.utils import timezone
-from rest_framework.decorators import api_view, permission_classes
+from rest_framework.decorators import api_view, permission_classes, throttle_classes
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework import status
-from drf_spectacular.utils import extend_schema, OpenApiExample
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema, OpenApiExample, OpenApiParameter
 
-from authentication.models import CustomUser
+from authentication.models import CustomUser, Role
 from property.models import Property
 from .models import Conversation, ConversationParticipant, Message
-from .serializers import ConversationSerializer, MessageSerializer
+from .participant_access import (
+    apply_search,
+    messaging_participants_base_queryset,
+    property_directory_user_id_list,
+    viewer_may_filter_by_property,
+)
+from .querysets import conversations_queryset_for_user, get_conversation_for_user
+from .serializers import (
+    ConversationSerializer,
+    MessageSerializer,
+    MessagingParticipantLookupSerializer,
+)
+from .throttling import MessagingParticipantsThrottle
 
 
 # ── Permission helpers ───────────────────────────────────────────────────────────
@@ -22,6 +36,12 @@ def is_participant(user, conversation):
 @extend_schema(
     methods=['GET'],
     summary="List conversations for the current user",
+    description=(
+        'Each row includes `participants` (see ConversationParticipant schema in Swagger components), '
+        '`primary_recipient` (user-centric summary or null), and `last_message` '
+        '(stable keys when non-null: id, sender, sender_id, sender_username, sender_name, body, created_at). '
+        'Field `participants[].user` is deprecated; prefer `user_id`.'
+    ),
 )
 @extend_schema(
     methods=['POST'],
@@ -44,14 +64,7 @@ def conversation_list_create(request):
     user = request.user
 
     if request.method == 'GET':
-        conversations = (
-            Conversation.objects
-            .filter(participants__user=user)
-            .select_related('created_by', 'property')
-            .prefetch_related('participants__user', 'messages')
-            .order_by('-messages__created_at')
-            .distinct()
-        )
+        conversations = conversations_queryset_for_user(user)
         serializer = ConversationSerializer(conversations, many=True, context={'request': request})
         return Response(serializer.data)
 
@@ -105,6 +118,7 @@ def conversation_list_create(request):
                 action_url=f'/api/messaging/conversations/{conversation.pk}/',
             )
 
+    conversation = get_conversation_for_user(user=user, pk=conversation.pk)
     serializer = ConversationSerializer(conversation, context={'request': request})
     return Response(serializer.data, status=status.HTTP_201_CREATED)
 
@@ -112,22 +126,22 @@ def conversation_list_create(request):
 @extend_schema(
     methods=['GET'],
     summary="Retrieve a conversation",
+    description=(
+        'Same payload shape as list rows. `primary_recipient` is null when there is no other participant. '
+        'Deprecated: `participants[].user` — use `user_id`.'
+    ),
 )
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
 def conversation_detail(request, pk):
-    try:
-        conversation = (
-            Conversation.objects
-            .select_related('created_by', 'property')
-            .prefetch_related('participants__user', 'messages')
-            .get(pk=pk)
-        )
-    except Conversation.DoesNotExist:
+    conversation = conversations_queryset_for_user(request.user).filter(pk=pk).first()
+    if conversation is None:
+        if Conversation.objects.filter(pk=pk).exists():
+            return Response(
+                {'detail': 'You are not a participant in this conversation.'},
+                status=status.HTTP_403_FORBIDDEN,
+            )
         return Response({'detail': 'Not found.'}, status=status.HTTP_404_NOT_FOUND)
-
-    if not is_participant(request.user, conversation):
-        return Response({'detail': 'You are not a participant in this conversation.'}, status=status.HTTP_403_FORBIDDEN)
 
     serializer = ConversationSerializer(conversation, context={'request': request})
     return Response(serializer.data)
@@ -154,7 +168,12 @@ def conversation_detail(request, pk):
 @permission_classes([IsAuthenticated])
 def message_list_create(request, pk):
     try:
-        conversation = Conversation.objects.select_related('created_by').prefetch_related('participants__user').get(pk=pk)
+        conversation = Conversation.objects.select_related('created_by').prefetch_related(
+            Prefetch(
+                'participants',
+                queryset=ConversationParticipant.objects.select_related('user', 'user__role'),
+            ),
+        ).get(pk=pk)
     except Conversation.DoesNotExist:
         return Response({'detail': 'Not found.'}, status=status.HTTP_404_NOT_FOUND)
 
@@ -193,6 +212,96 @@ def message_list_create(request, pk):
     return Response(serializer.data, status=status.HTTP_201_CREATED)
 
 
+# ── Participant lookup (compose new conversation) ─────────────────────────────────
+
+@extend_schema(
+    methods=['GET'],
+    summary='List users you may invite to a new conversation',
+    description=(
+        'Role-scoped directory for the messaging compose flow. '
+        'See `messaging.participant_access` module docstring for the permission matrix.'
+    ),
+    parameters=[
+        OpenApiParameter(
+            'search',
+            OpenApiTypes.STR,
+            description='Case-insensitive match on username, name, email, or phone.',
+        ),
+        OpenApiParameter(
+            'property',
+            OpenApiTypes.INT,
+            description=(
+                'Optional. Restrict to owner, appointed agents, and active tenants on this '
+                'property. MovingCompany users cannot use this filter.'
+            ),
+        ),
+        OpenApiParameter(
+            'limit',
+            OpenApiTypes.INT,
+            description='Page size (default 20, max 100).',
+        ),
+    ],
+    examples=[
+        OpenApiExample(
+            'Example response',
+            response_only=True,
+            value={
+                'results': [
+                    {
+                        'user_id': 12,
+                        'full_name': 'Ann Tenant',
+                        'email': 'ann@example.com',
+                        'phone': '+254700000000',
+                        'role': 'Tenant',
+                        'avatar_url': None,
+                        'is_active': True,
+                    }
+                ]
+            },
+        ),
+    ],
+)
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
+@throttle_classes([MessagingParticipantsThrottle])
+def messaging_participants_lookup(request):
+    try:
+        limit = int(request.query_params.get('limit', 20))
+    except (TypeError, ValueError):
+        return Response({'detail': 'Invalid limit.'}, status=status.HTTP_400_BAD_REQUEST)
+    limit = max(1, min(limit, 100))
+
+    user = request.user
+    qs = messaging_participants_base_queryset(user)
+
+    prop_raw = request.query_params.get('property')
+    if prop_raw not in (None, ''):
+        if getattr(user, 'role_id', None) and user.role.name == Role.MOVING_COMPANY:
+            return Response(
+                {'detail': 'The property filter is not supported for your role.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        try:
+            property_id = int(prop_raw)
+        except (TypeError, ValueError):
+            return Response({'detail': 'Invalid property id.'}, status=status.HTTP_400_BAD_REQUEST)
+        try:
+            prop = Property.objects.get(pk=property_id)
+        except Property.DoesNotExist:
+            return Response({'detail': 'Property not found.'}, status=status.HTTP_404_NOT_FOUND)
+        if not viewer_may_filter_by_property(user, prop):
+            return Response(
+                {'detail': 'You do not have access to this property.'},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        qs = qs.filter(pk__in=property_directory_user_id_list(prop))
+
+    search = request.query_params.get('search', '') or ''
+    qs = apply_search(qs, search).order_by('username')[:limit]
+    serializer = MessagingParticipantLookupSerializer(qs, many=True)
+    return Response({'results': serializer.data})
+
+
 # ── Mark read ─────────────────────────────────────────────────────────────────────
 
 @extend_schema(
@@ -210,7 +319,12 @@ def message_list_create(request, pk):
 @permission_classes([IsAuthenticated])
 def conversation_mark_read(request, pk):
     try:
-        conversation = Conversation.objects.prefetch_related('participants__user').get(pk=pk)
+        conversation = Conversation.objects.prefetch_related(
+            Prefetch(
+                'participants',
+                queryset=ConversationParticipant.objects.select_related('user', 'user__role'),
+            ),
+        ).get(pk=pk)
     except Conversation.DoesNotExist:
         return Response({'detail': 'Not found.'}, status=status.HTTP_404_NOT_FOUND)
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce a role-scoped messaging participant directory endpoint and enrich conversation payloads with normalized participant, primary_recipient, and last_message metadata while keeping backward compatibility for existing clients.

New Features:
- Add GET /api/messaging/participants/ endpoint providing a role-scoped directory of users eligible for starting new conversations, with search, optional property scoping, pagination limit, and throttling.
- Expose primary_recipient and enriched last_message metadata on conversation list and detail responses for easier frontend display.
- Normalize participant information on conversation payloads to include user_id, contact details, role, and self-identification flags, while keeping the legacy user field as an alias.

Enhancements:
- Refactor conversation query logic into shared annotated querysets to avoid N+1 queries and support efficient unread_count and last_message computation.
- Improve permission handling for conversation detail retrieval to distinguish not-found from not-a-participant cases.
- Enhance API documentation and README/CLAUDE docs to describe messaging payload shapes, participant directory behavior, and frontend migration guidance.

Documentation:
- Document the messaging participant directory endpoint, updated conversation payload schema, and migration notes for frontend clients in the API integration guide, README, and CLAUDE architecture notes.

Tests:
- Add schema-focused API contract tests for messaging conversation list/detail and participant directory payloads, plus additional behavioral tests for participant lookup, shapes, and query bounds.