### PR TITLE
Add PATCH partial update for nested unit lease endpoint

### DIFF
--- a/property/serializers.py
+++ b/property/serializers.py
@@ -46,6 +46,18 @@ class LeaseSerializer(serializers.ModelSerializer):
         read_only_fields = ['unit']
 
 
+class LeasePartialUpdateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Lease
+        fields = ['start_date', 'end_date', 'rent_amount', 'is_active']
+        extra_kwargs = {
+            'start_date': {'required': False},
+            'end_date': {'required': False},
+            'rent_amount': {'required': False},
+            'is_active': {'required': False},
+        }
+
+
 class PropertyAgentSerializer(serializers.ModelSerializer):
     class Meta:
         model = PropertyAgent

--- a/property/tests.py
+++ b/property/tests.py
@@ -281,6 +281,71 @@ def make_lease(unit, tenant, end_date=None):
     )
 
 
+class UnitLeaseEndpointTests(APITestCase):
+    def setUp(self):
+        self.landlord, self.landlord_token = make_user('lease_ll', 'Landlord')
+        self.other_landlord, self.other_token = make_user('lease_ol', 'Landlord')
+        self.agent, self.agent_token = make_user('lease_ag', 'Agent')
+        self.tenant, self.tenant_token = make_user('lease_tn', 'Tenant')
+        self.prop = make_property(self.landlord)
+        self.unit = make_unit(self.prop, self.landlord)
+        self.unit.is_occupied = True
+        self.unit.save()
+        self.lease = make_lease(self.unit, self.tenant)
+        PropertyAgent.objects.create(property=self.prop, agent=self.agent, appointed_by=self.landlord)
+        self.url = reverse('lease-list-create', args=[self.unit.id])
+
+    def auth(self, token):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {token.key}')
+
+    def test_landlord_patch_lease_returns_full_json(self):
+        self.auth(self.landlord_token)
+        new_start = date.today() + timedelta(days=10)
+        response = self.client.patch(self.url, {
+            'start_date': str(new_start),
+            'rent_amount': '50000.00',
+            'is_active': False,
+        }, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['id'], self.lease.id)
+        self.assertEqual(response.data['unit'], self.unit.id)
+        self.assertEqual(response.data['tenant'], self.tenant.id)
+        self.assertEqual(response.data['start_date'], str(new_start))
+        self.assertEqual(response.data['rent_amount'], '50000.00')
+        self.assertFalse(response.data['is_active'])
+        self.lease.refresh_from_db()
+        self.assertEqual(str(self.lease.rent_amount), '50000.00')
+        self.assertFalse(self.lease.is_active)
+
+    def test_assigned_agent_can_patch_lease(self):
+        self.auth(self.agent_token)
+        response = self.client.patch(self.url, {'end_date': str(date.today() + timedelta(days=400))}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('id', response.data)
+
+    def test_other_landlord_forbidden(self):
+        self.auth(self.other_token)
+        response = self.client.patch(self.url, {'rent_amount': '1.00'}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_tenant_forbidden(self):
+        self.auth(self.tenant_token)
+        response = self.client.patch(self.url, {'rent_amount': '1.00'}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_patch_no_lease_returns_404(self):
+        empty_unit = Unit.objects.create(
+            property=self.prop, name='Empty', price='1000', created_by=self.landlord, is_public=True,
+        )
+        self.auth(self.landlord_token)
+        response = self.client.patch(
+            reverse('lease-list-create', args=[empty_unit.id]),
+            {'rent_amount': '100.00'},
+            format='json',
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
 class TenantApplicationTests(APITestCase):
     def setUp(self):
         self.landlord, self.landlord_token = make_user('landlord1', 'Landlord')

--- a/property/views.py
+++ b/property/views.py
@@ -26,7 +26,7 @@ from .models import (
 )
 from .serializers import (
     PropertySerializer, UnitSerializer, PropertyImageSerializer,
-    LeaseSerializer, PropertyAgentSerializer, TenantApplicationSerializer,
+    LeaseSerializer, LeasePartialUpdateSerializer, PropertyAgentSerializer, TenantApplicationSerializer,
     LeaseDocumentSerializer, PropertyReviewSerializer, TenantReviewSerializer,
     SavedSearchSerializer,
     TenantInvitationSerializer,
@@ -297,7 +297,19 @@ def unit_image_detail(request, unit_id, image_id):
         })
     ],
 )
-@api_view(['GET', 'POST'])
+@extend_schema(
+    methods=['PATCH'],
+    summary="Partially update a unit lease",
+    examples=[
+        OpenApiExample("Patch lease", request_only=True, value={
+            "start_date": "2026-05-01",
+            "end_date": "2028-04-30",
+            "rent_amount": "47500.00",
+            "is_active": True,
+        })
+    ],
+)
+@api_view(['GET', 'POST', 'PATCH'])
 @permission_classes([IsAuthenticated])
 def lease_list_create(request, unit_id):
     try:
@@ -322,6 +334,16 @@ def lease_list_create(request, unit_id):
             unit.is_occupied = True
             unit.save()
             return Response(serializer.data, status=status.HTTP_201_CREATED)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    elif request.method == 'PATCH':
+        lease = getattr(unit, 'lease', None)
+        if not lease:
+            return Response({'detail': 'No lease for this unit.'}, status=status.HTTP_404_NOT_FOUND)
+        serializer = LeasePartialUpdateSerializer(lease, data=request.data, partial=True)
+        if serializer.is_valid():
+            serializer.save()
+            return Response(LeaseSerializer(lease).data, status=status.HTTP_200_OK)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 


### PR DESCRIPTION
Made-with: Cursor

## Summary by Sourcery

Add partial update support for unit leases via the nested lease endpoint.

New Features:
- Allow PATCH requests on the nested unit lease endpoint to partially update existing leases.

Documentation:
- Document the lease PATCH operation in the OpenAPI schema with example payloads.

Tests:
- Add API tests covering successful lease patching, role-based access control, and 404 behavior when no lease exists.