### PR TITLE
Document PATCH for unit nested lease endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,7 +213,7 @@ Seeded via data migrations. Roles are:
 | GET/PUT | `/api/property/units/<pk>/` | Admin, owner, assigned agent |
 | DELETE | `/api/property/units/<pk>/` | Admin, owner only |
 | GET/POST | `/api/property/units/<pk>/images/` | GET=any, POST=admin/owner/agent |
-| GET/POST | `/api/property/units/<pk>/lease/` | Admin, owner, assigned agent |
+| GET/POST/PATCH | `/api/property/units/<pk>/lease/` | Admin, owner, assigned agent — PATCH partial update (`start_date`, `end_date`, `rent_amount`, `is_active`); `200` returns full lease JSON |
 | GET/POST | `/api/property/units/<pk>/tenant-invitations/` | List/create invites — owner or assigned agent; if email matches existing Tenant, creates lease instead of invite |
 | POST | `/api/property/tenant-invitations/<pk>/resend/` | Owner or assigned agent — new token + email |
 | GET | `/api/property/units/public/` | No auth required |

--- a/docs/api-integration.md
+++ b/docs/api-integration.md
@@ -677,8 +677,11 @@ python manage.py match_saved_searches --days 7  # last 7 days
 
 ### Unit Lease
 
-`GET /api/property/units/<pk>/lease/` — get active lease
+`GET /api/property/units/<pk>/lease/` — get active lease (`404` if none)
+
 `POST /api/property/units/<pk>/lease/` — create lease
+
+`PATCH /api/property/units/<pk>/lease/` — partial update of an existing lease (same auth as GET/POST: admin, property owner, or assigned agent). Writable fields only: `start_date`, `end_date`, `rent_amount`, `is_active` (all optional in the body). Returns **`200`** with the **full** lease object (same shape as GET). **`404`** if the unit has no lease.
 
 ```json
 {
@@ -691,6 +694,16 @@ python manage.py match_saved_searches --days 7  # last 7 days
 ```
 
 `unit` is set from the URL — do not include it in the body.
+
+Example PATCH body (send only fields to change):
+
+```json
+{
+  "rent_amount": "26000.00",
+  "end_date": "2025-06-30",
+  "is_active": true
+}
+```
 
 ---
 


### PR DESCRIPTION
Made-with: Cursor

## Summary by Sourcery

Document PATCH support for the unit lease nested endpoint and clarify response behavior.

Documentation:
- Describe the GET unit lease endpoint’s 404 behavior when no active lease exists and document the PATCH unit lease endpoint’s semantics, writable fields, and example request body.

Chores:
- Update internal endpoint permissions table to include PATCH for the unit lease nested endpoint with a brief description of behavior.