### PR TITLE
feat(property): multipart lease document uploads and authenticated do…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ db.sqlite3
 venv
 .idea
 __pycache__/
+
+media/
+.DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,7 +220,9 @@ Seeded via data migrations. Roles are:
 | GET/POST | `/api/property/applications/` | Landlord=own units, Tenant=own, Admin=all |
 | GET/PUT | `/api/property/applications/<pk>/` | Landlord: approve/reject — Tenant: withdraw |
 | GET | `/api/property/dashboard/` | Landlord / Admin |
-| GET/POST | `/api/property/leases/<lease_id>/documents/` | Owner/Agent=POST, Tenant on lease=GET |
+| GET/POST | `/api/property/leases/<lease_id>/documents/` | Owner/Agent=POST (multipart `file` or legacy JSON `file_url`), Tenant on lease=GET |
+| GET | `/api/property/leases/<lease_id>/documents/<doc_id>/download/` | Owner/Agent/Tenant on lease — binary; 404 if legacy external URL only |
+| GET/PUT/PATCH/DELETE | `/api/property/leases/<lease_id>/documents/<doc_id>/` | GET: same as list scope; PUT/PATCH: owner/agent; DELETE: owner/agent |
 | POST | `/api/property/leases/<lease_id>/documents/<doc_id>/sign/` | Tenant on lease only |
 | GET/POST | `/api/property/properties/<property_id>/reviews/` | GET=any auth, POST=Tenant (active/past lease) or Landlord (owns property) |
 | GET/PATCH/DELETE | `/api/property/properties/<property_id>/reviews/<review_id>/` | Reviewer or Admin |
@@ -488,9 +490,12 @@ Any uncaught exception (IntegrityError, etc.) that propagates out of a view duri
 - Status transitions are enforced in `_validate_status_transition()` in `disputes/views.py`
 
 ### Lease Documents
-- `file_url` is a plain `CharField(500)` — document storage is external; the API stores URLs, not files
+- **Uploads:** `LeaseDocument.file` (`FileField`) stores PDF/images under `lease_documents/<lease_id>/<uuid>.<ext>` (private disk/bucket; not guessable). **API response `file_url`** is a server-generated absolute URL to `GET …/documents/<id>/download/` (authenticated) for uploaded files; legacy rows may still expose an external URL only.
+- **Legacy:** JSON create with `file_url` (pre-hosted URL) remains supported during deprecation; do not send both `file` and `file_url` on create.
+- **Limits:** 25 MB max; types PDF, PNG, JPEG, GIF, WebP (`property/lease_document_validators.py`).
+- **Migration:** Existing rows with external `file_url` only are unchanged; download returns 404 until re-uploaded or imported server-side.
 - Signing sets `signed_by` (FK to user) and `signed_at` (timestamp) — no cryptographic signing
-- Only the tenant on the lease can sign; only the owner/agent can upload
+- Only the tenant on the lease can sign; only the owner/agent can upload/update/delete
 
 ### Search & Saved Searches
 - `GET /api/property/units/public/` supports query params: `price_min`, `price_max`, `bedrooms`, `bathrooms`, `property_type`, `amenities` (keyword), `parking=true`, `lat`+`lng`+`radius_km` (bounding-box distance filter)

--- a/docs/api-integration.md
+++ b/docs/api-integration.md
@@ -1889,7 +1889,11 @@ Returns chronological activity events for the request (request creation, bids, n
 
 ## Lease Documents
 
-Attached to a specific lease. Stores a URL to the document (no file upload — supply a pre-hosted URL).
+Attached to a specific lease. **Preferred:** upload the binary with `multipart/form-data` (`file` field). **Legacy (deprecation window):** JSON body with `file_url` pointing at a pre-hosted URL. The API never trusts client-supplied URLs for server-stored files.
+
+**Upload limits:** max **25 MB** per file. **Allowed types:** PDF, PNG, JPEG, GIF, WebP (validated by extension and `Content-Type`).
+
+**`file_url` in JSON responses:** For uploads stored by the API, `file_url` is a **server-generated absolute URL** to the authenticated download endpoint (same host as the API), not a direct bucket path. For legacy rows created with JSON `file_url` only, `file_url` remains the external URL until migrated.
 
 ### List Documents for a Lease (Owner / Agent / Tenant on that lease)
 
@@ -1903,7 +1907,7 @@ Attached to a specific lease. Stores a URL to the document (no file upload — s
     "lease": 2,
     "document_type": "lease_agreement",
     "title": "Lease Agreement — Unit A1 2024",
-    "file_url": "https://storage.example.com/docs/lease-a1-2024.pdf",
+    "file_url": "https://api.example.com/api/property/leases/2/documents/1/download/",
     "uploaded_by": 3,
     "signed_by": 5,
     "signed_at": "2024-02-01T10:00:00Z",
@@ -1916,6 +1920,41 @@ Attached to a specific lease. Stores a URL to the document (no file upload — s
 
 `POST /api/property/leases/<lease_id>/documents/`
 
+**Preferred — `multipart/form-data`**
+
+| Field           | Required | Description |
+|----------------|----------|-------------|
+| `document_type`| Yes      | One of: `lease_agreement`, `addendum`, `notice`, `other` |
+| `title`        | Yes      | Human-readable title |
+| `file`         | Yes      | Binary (PDF or image); max 25 MB |
+
+```http
+POST /api/property/leases/2/documents/
+Authorization: Token …
+Content-Type: multipart/form-data; boundary=----…
+
+------…
+Content-Disposition: form-data; name="document_type"
+
+lease_agreement
+------…
+Content-Disposition: form-data; name="title"
+
+Lease Agreement — Unit A1 2024
+------…
+Content-Disposition: form-data; name="file"; filename="lease.pdf"
+Content-Type: application/pdf
+
+<binary>
+------…--
+```
+
+```json
+// Response 201 — same shape as GET detail; file_url points at …/documents/<id>/download/
+```
+
+**Legacy — `application/json` (optional deprecation window)**
+
 ```json
 {
   "document_type": "lease_agreement",
@@ -1924,7 +1963,9 @@ Attached to a specific lease. Stores a URL to the document (no file upload — s
 }
 ```
 
-Document type choices: `lease_agreement`, `addendum`, `notice`, `inspection_report`, `other`
+Do not send both `file` and `file_url` on create.
+
+**Errors:** `400` — validation (e.g. wrong extension, invalid URL, missing file/url); `403` — not owner/agent; `413` — file larger than 25 MB (after server size limits).
 
 ### Get a Document (Owner / Agent / Tenant on that lease)
 
@@ -1937,13 +1978,28 @@ Document type choices: `lease_agreement`, `addendum`, `notice`, `inspection_repo
   "lease": 2,
   "document_type": "lease_agreement",
   "title": "Lease Agreement — Unit A1 2024",
-  "file_url": "https://storage.example.com/docs/lease-a1-2024.pdf",
+  "file_url": "https://api.example.com/api/property/leases/2/documents/1/download/",
   "uploaded_by": 3,
   "signed_by": 5,
   "signed_at": "2024-02-01T10:00:00Z",
   "created_at": "2024-02-01T08:00:00Z"
 }
 ```
+
+### Download uploaded file (Owner / Agent / Tenant on that lease)
+
+`GET /api/property/leases/<lease_id>/documents/<doc_id>/download/`
+
+Returns the stored file with `Content-Disposition: attachment` and an appropriate `Content-Type`. Requires authentication; same access rules as document detail.
+
+Returns `404` if the document only has a legacy external `file_url` (no server file) — clients should use the URL from the document JSON in that case.
+
+### Update a Document (Owner / Agent)
+
+`PUT` / `PATCH /api/property/leases/<lease_id>/documents/<doc_id>/` (partial update)
+
+- **JSON:** may update `document_type`, `title`, and for **legacy-only** documents (no uploaded `file`), `file_url`.
+- **Multipart:** send a new `file` to replace the stored object (optional together with `title` / `document_type`). You cannot set `file_url` on a document that already has a server-stored file; use a new `file` instead.
 
 ### Delete a Document (Owner / Agent only)
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -101,11 +101,13 @@ python manage.py runserver
 
 The API runs at `http://localhost:8000`.
 
-| URL | Description |
-|-----|-------------|
-| `http://localhost:8000/api/docs/` | Swagger UI |
-| `http://localhost:8000/api/redoc/` | ReDoc |
+
+| URL                                 | Description             |
+| ----------------------------------- | ----------------------- |
+| `http://localhost:8000/api/docs/`   | Swagger UI              |
+| `http://localhost:8000/api/redoc/`  | ReDoc                   |
 | `http://localhost:8000/api/schema/` | OpenAPI schema download |
+
 
 If port 8000 is already in use:
 
@@ -212,10 +214,13 @@ STRIPE_WEBHOOK_SECRET=whsec_<from-stripe-cli>
 
 ## Common issues
 
-| Problem | Fix |
-|---------|-----|
-| `OperationalError: could not connect to server` | Supabase project is paused — log in and resume it |
-| `Port 8000 already in use` | Run `lsof -ti:8000 \| xargs kill -9` or use port 8001 |
-| `makemigrations` fails | Expected — write migrations by hand. See [CONTRIBUTING.md](../CONTRIBUTING.md#migrations) |
-| Test runner hangs asking to delete test DB | Use `--noinput` flag or type `yes` |
+
+| Problem                                              | Fix                                                                                                       |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `OperationalError: could not connect to server`      | Supabase project is paused — log in and resume it                                                         |
+| `Port 8000 already in use`                           | Run `lsof -ti:8000 | xargs kill -9` or use port 8001                                                      |
+| `makemigrations` fails                               | Expected — write migrations by hand. See [CONTRIBUTING.md](../CONTRIBUTING.md#migrations)                 |
+| Test runner hangs asking to delete test DB           | Use `--noinput` flag or type `yes`                                                                        |
 | `django.template.context.BaseContext` error in tests | An unhandled exception propagated out of a view — wrap `serializer.save()` in `try/except IntegrityError` |
+
+

--- a/maintenance/migrations/0002_alter_maintenancerequest_category_priority.py
+++ b/maintenance/migrations/0002_alter_maintenancerequest_category_priority.py
@@ -1,0 +1,51 @@
+from django.db import migrations, models
+
+
+def forwards_priority_emergency_to_urgent(apps, schema_editor):
+    MaintenanceRequest = apps.get_model('maintenance', 'MaintenanceRequest')
+    MaintenanceRequest.objects.filter(priority='emergency').update(priority='urgent')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('maintenance', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            forwards_priority_emergency_to_urgent,
+            migrations.RunPython.noop,
+        ),
+        migrations.AlterField(
+            model_name='maintenancerequest',
+            name='category',
+            field=models.CharField(
+                choices=[
+                    ('plumbing', 'Plumbing'),
+                    ('electrical', 'Electrical'),
+                    ('structural', 'Structural'),
+                    ('appliance', 'Appliance'),
+                    ('capentry', 'Carpentry'),
+                    ('painting', 'Painting'),
+                    ('masonry', 'Masonry'),
+                    ('other', 'Other'),
+                ],
+                max_length=20,
+            ),
+        ),
+        migrations.AlterField(
+            model_name='maintenancerequest',
+            name='priority',
+            field=models.CharField(
+                choices=[
+                    ('low', 'Low'),
+                    ('medium', 'Medium'),
+                    ('high', 'High'),
+                    ('urgent', 'Urgent'),
+                ],
+                default='medium',
+                max_length=20,
+            ),
+        ),
+    ]

--- a/maintenance/models.py
+++ b/maintenance/models.py
@@ -10,7 +10,7 @@ class MaintenanceRequest(models.Model):
         ('electrical', 'Electrical'),
         ('structural', 'Structural'),
         ('appliance', 'Appliance'),
-        ('capentry', 'Carpentry'),
+        ('carpentry', 'Carpentry'),
         ('painting', 'Painting'),
         ('masonry', 'Masonry'),
         ('other', 'Other'),

--- a/maintenance/models.py
+++ b/maintenance/models.py
@@ -10,13 +10,16 @@ class MaintenanceRequest(models.Model):
         ('electrical', 'Electrical'),
         ('structural', 'Structural'),
         ('appliance', 'Appliance'),
+        ('capentry', 'Carpentry'),
+        ('painting', 'Painting'),
+        ('masonry', 'Masonry'),
         ('other', 'Other'),
     ]
     PRIORITY_CHOICES = [
         ('low', 'Low'),
         ('medium', 'Medium'),
         ('high', 'High'),
-        ('emergency', 'Emergency'),
+        ('urgent', 'Urgent'),
     ]
     STATUS_CHOICES = [
         ('submitted', 'Submitted'),

--- a/property/lease_document_validators.py
+++ b/property/lease_document_validators.py
@@ -1,0 +1,46 @@
+"""Validation for lease document file uploads (size, extension, content type)."""
+
+from __future__ import annotations
+
+import os
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+from rest_framework.exceptions import APIException
+
+# PDF + common images; max 25 MB (aligned with DATA_UPLOAD_MAX_MEMORY_SIZE in settings).
+MAX_LEASE_DOCUMENT_BYTES = 25 * 1024 * 1024
+
+_ALLOWED_EXT = frozenset({'.pdf', '.png', '.jpg', '.jpeg', '.gif', '.webp'})
+_ALLOWED_TYPES = frozenset({
+    'application/pdf',
+    'image/png',
+    'image/jpeg',
+    'image/gif',
+    'image/webp',
+})
+
+
+class LeaseDocumentPayloadTooLarge(APIException):
+    status_code = 413
+    default_detail = 'File too large.'
+
+
+def validate_lease_document_upload(upload) -> None:
+    """Raise LeaseDocumentPayloadTooLarge or DjangoValidationError if upload is not allowed."""
+    if upload.size > MAX_LEASE_DOCUMENT_BYTES:
+        raise LeaseDocumentPayloadTooLarge(
+            detail=f'File too large. Maximum size is {MAX_LEASE_DOCUMENT_BYTES // (1024 * 1024)} MB.',
+        )
+    name = getattr(upload, 'name', '') or ''
+    ext = os.path.splitext(name)[1].lower()
+    if ext not in _ALLOWED_EXT:
+        raise DjangoValidationError(
+            'Unsupported file type. Allowed: PDF, PNG, JPEG, GIF, WebP.',
+            code='invalid_extension',
+        )
+    content_type = getattr(upload, 'content_type', '') or ''
+    if content_type and content_type not in _ALLOWED_TYPES:
+        raise DjangoValidationError(
+            'Unsupported content type for this file.',
+            code='invalid_content_type',
+        )

--- a/property/migrations/0010_lease_document_file_upload.py
+++ b/property/migrations/0010_lease_document_file_upload.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('property', '0009_tenant_invitation'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='leasedocument',
+            name='file',
+            field=models.FileField(
+                blank=True,
+                null=True,
+                upload_to='property.models.lease_document_upload_to',
+            ),
+        ),
+        migrations.AlterField(
+            model_name='leasedocument',
+            name='file_url',
+            field=models.CharField(blank=True, max_length=500, null=True),
+        ),
+    ]

--- a/property/models.py
+++ b/property/models.py
@@ -1,4 +1,7 @@
 from django.core.validators import MinValueValidator, MaxValueValidator
+import os
+import uuid
+
 from django.db import models
 
 from authentication.models import CustomUser
@@ -124,6 +127,14 @@ class TenantApplication(models.Model):
 		return f"Application by {self.applicant.username} for {self.unit}"
 
 
+def lease_document_upload_to(instance, filename):
+	"""Scoped storage path: lease_documents/<lease_id>/<uuid>.<ext> (non-guessable)."""
+	ext = os.path.splitext(filename)[1].lower()
+	if ext not in ('.pdf', '.png', '.jpg', '.jpeg', '.gif', '.webp'):
+		ext = '.bin'
+	return f'lease_documents/{instance.lease_id}/{uuid.uuid4().hex}{ext}'
+
+
 class LeaseDocument(models.Model):
 	DOCUMENT_TYPES = [
 		('lease_agreement', 'Lease Agreement'),
@@ -134,7 +145,9 @@ class LeaseDocument(models.Model):
 	lease = models.ForeignKey(Lease, on_delete=models.CASCADE, related_name='documents')
 	document_type = models.CharField(max_length=20, choices=DOCUMENT_TYPES)
 	title = models.CharField(max_length=200)
-	file_url = models.CharField(max_length=500)
+	# Legacy: external URL only. New uploads use `file`; API exposes download URL as file_url.
+	file_url = models.CharField(max_length=500, blank=True, null=True)
+	file = models.FileField(upload_to=lease_document_upload_to, blank=True, null=True)
 	uploaded_by = models.ForeignKey(CustomUser, on_delete=models.CASCADE, related_name='uploaded_documents')
 	signed_by = models.ForeignKey(
 		CustomUser, null=True, blank=True, on_delete=models.SET_NULL, related_name='signed_documents'
@@ -144,6 +157,11 @@ class LeaseDocument(models.Model):
 
 	def __str__(self):
 		return f"LeaseDocument({self.title} — {self.document_type})"
+
+	def delete(self, *args, **kwargs):
+		if self.file:
+			self.file.delete(save=False)
+		super().delete(*args, **kwargs)
 
 
 class PropertyReview(models.Model):

--- a/property/serializers.py
+++ b/property/serializers.py
@@ -1,4 +1,8 @@
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.core.validators import URLValidator
+from django.urls import reverse
 from rest_framework import serializers
+from .lease_document_validators import validate_lease_document_upload
 from .models import (
     Property,
     Unit,
@@ -73,10 +77,86 @@ class TenantApplicationSerializer(serializers.ModelSerializer):
 
 
 class LeaseDocumentSerializer(serializers.ModelSerializer):
+    """Create with multipart `file` (preferred) or JSON `file_url` (legacy)."""
+
+    file = serializers.FileField(write_only=True, required=False, allow_null=True)
+
     class Meta:
         model = LeaseDocument
-        fields = ['id', 'lease', 'document_type', 'title', 'file_url', 'uploaded_by', 'signed_by', 'signed_at', 'created_at']
+        fields = [
+            'id', 'lease', 'document_type', 'title', 'file_url', 'file',
+            'uploaded_by', 'signed_by', 'signed_at', 'created_at',
+        ]
         read_only_fields = ['id', 'lease', 'uploaded_by', 'signed_by', 'signed_at', 'created_at']
+        extra_kwargs = {
+            'file_url': {'required': False, 'allow_null': True, 'allow_blank': True},
+        }
+
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        request = self.context.get('request')
+        if instance.file:
+            rel = reverse(
+                'lease-document-download',
+                kwargs={'lease_id': instance.lease_id, 'doc_id': instance.pk},
+            )
+            data['file_url'] = request.build_absolute_uri(rel) if request else rel
+        elif data.get('file_url') is None:
+            data['file_url'] = ''
+        return data
+
+    def validate_file(self, value):
+        if value is None:
+            return value
+        try:
+            validate_lease_document_upload(value)
+        except DjangoValidationError as e:
+            raise serializers.ValidationError(list(e.messages))
+        return value
+
+    def validate_file_url(self, value):
+        if value in (None, ''):
+            return value
+        validator = URLValidator()
+        try:
+            validator(value)
+        except DjangoValidationError:
+            raise serializers.ValidationError('Enter a valid URL.')
+        return value
+
+    def validate(self, attrs):
+        if self.instance is None:
+            f = attrs.get('file')
+            url = attrs.get('file_url')
+            if not f and not url:
+                raise serializers.ValidationError(
+                    'Provide either file (multipart upload) or file_url (legacy JSON with a pre-hosted URL).',
+                )
+            if f and url:
+                raise serializers.ValidationError('Provide only one of file or file_url.')
+            return attrs
+
+        if self.instance.file and attrs.get('file_url'):
+            raise serializers.ValidationError(
+                'This document is stored on the server; send a new file to replace it, or clear file_url.',
+            )
+        return attrs
+
+    def create(self, validated_data):
+        file = validated_data.pop('file', None)
+        if file:
+            validated_data['file'] = file
+            validated_data['file_url'] = None
+        return super().create(validated_data)
+
+    def update(self, instance, validated_data):
+        new_file = validated_data.pop('file', None)
+        if new_file is not None:
+            if instance.file:
+                instance.file.delete(save=False)
+            validated_data['file'] = new_file
+            validated_data['file_url'] = None
+        return super().update(instance, validated_data)
 
 
 class PropertyReviewSerializer(serializers.ModelSerializer):

--- a/property/tests.py
+++ b/property/tests.py
@@ -1,5 +1,7 @@
 from datetime import date, timedelta
+from unittest.mock import patch
 
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework.test import APITestCase
@@ -626,6 +628,73 @@ class LeaseDocumentTests(APITestCase):
         self.auth(self.landlord_token)
         response = self.client.post(self._doc_sign_url(doc.id))
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_multipart_upload_exposes_download_url_as_file_url(self):
+        self.auth(self.landlord_token)
+        pdf = SimpleUploadedFile('lease.pdf', b'%PDF-1.4 test', content_type='application/pdf')
+        response = self.client.post(
+            self._doc_list_url(),
+            {'document_type': 'lease_agreement', 'title': 'Multipart lease', 'file': pdf},
+            format='multipart',
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertIn('/documents/%s/download/' % response.data['id'], response.data['file_url'])
+
+    def test_tenant_can_download_server_stored_file(self):
+        self.auth(self.landlord_token)
+        pdf = SimpleUploadedFile('a.pdf', b'%PDF-1.4 x', content_type='application/pdf')
+        r = self.client.post(
+            self._doc_list_url(),
+            {'document_type': 'other', 'title': 'Doc', 'file': pdf},
+            format='multipart',
+        )
+        doc_id = r.data['id']
+        download_url = reverse('lease-document-download', args=[self.lease.id, doc_id])
+        self.auth(self.tenant_token)
+        dr = self.client.get(download_url)
+        self.assertEqual(dr.status_code, status.HTTP_200_OK)
+        self.assertEqual(dr['Content-Type'], 'application/pdf')
+
+    def test_download_legacy_external_only_returns_404(self):
+        doc = self._make_doc()
+        download_url = reverse('lease-document-download', args=[self.lease.id, doc.id])
+        self.auth(self.tenant_token)
+        dr = self.client.get(download_url)
+        self.assertEqual(dr.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_invalid_file_extension_rejected(self):
+        self.auth(self.landlord_token)
+        bad = SimpleUploadedFile('x.exe', b'MZ\x00', content_type='application/octet-stream')
+        response = self.client.post(
+            self._doc_list_url(),
+            {'document_type': 'lease_agreement', 'title': 'bad', 'file': bad},
+            format='multipart',
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_oversize_upload_returns_413(self):
+        self.auth(self.landlord_token)
+        with patch('property.lease_document_validators.MAX_LEASE_DOCUMENT_BYTES', 50):
+            pdf = SimpleUploadedFile('huge.pdf', b'x' * 100, content_type='application/pdf')
+            response = self.client.post(
+                self._doc_list_url(),
+                {'document_type': 'lease_agreement', 'title': 'big', 'file': pdf},
+                format='multipart',
+            )
+        self.assertEqual(response.status_code, status.HTTP_413_REQUEST_ENTITY_TOO_LARGE)
+
+    def test_landlord_can_patch_document_title(self):
+        self.auth(self.landlord_token)
+        pdf = SimpleUploadedFile('b.pdf', b'%PDF-1.4', content_type='application/pdf')
+        r = self.client.post(
+            self._doc_list_url(),
+            {'document_type': 'notice', 'title': 'Original', 'file': pdf},
+            format='multipart',
+        )
+        detail = reverse('lease-document-detail', args=[self.lease.id, r.data['id']])
+        response = self.client.patch(detail, {'title': 'Updated title'}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['title'], 'Updated title')
 
 
 class PropertyReviewTests(APITestCase):

--- a/property/urls.py
+++ b/property/urls.py
@@ -21,6 +21,11 @@ urlpatterns = [
     path('dashboard/', views.landlord_dashboard, name='landlord-dashboard'),
     # Lease documents
     path('leases/<int:lease_id>/documents/', views.lease_document_list_create, name='lease-document-list-create'),
+    path(
+        'leases/<int:lease_id>/documents/<int:doc_id>/download/',
+        views.lease_document_download,
+        name='lease-document-download',
+    ),
     path('leases/<int:lease_id>/documents/<int:doc_id>/', views.lease_document_detail, name='lease-document-detail'),
     path('leases/<int:lease_id>/documents/<int:doc_id>/sign/', views.lease_document_sign, name='lease-document-sign'),
     # Property reviews

--- a/property/views.py
+++ b/property/views.py
@@ -1,16 +1,19 @@
 import math
+import mimetypes
+import os
 from datetime import date, timedelta
 from decimal import Decimal
 from django.db import IntegrityError, transaction
 from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError as DjangoValidationError
 
+from django.http import FileResponse
 from django.utils import timezone
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.response import Response
 from rest_framework import status
-from drf_spectacular.utils import extend_schema, OpenApiExample
+from drf_spectacular.utils import extend_schema, OpenApiExample, OpenApiResponse
 from .models import (
     Property,
     Unit,
@@ -784,16 +787,68 @@ def landlord_dashboard(request):
 
 # ── Lease Documents ───────────────────────────────────────────────────────────
 
+_LEASE_DOC_MULTIPART_SCHEMA = {
+    'multipart/form-data': {
+        'type': 'object',
+        'properties': {
+            'document_type': {
+                'type': 'string',
+                'enum': ['lease_agreement', 'addendum', 'notice', 'other'],
+            },
+            'title': {'type': 'string'},
+            'file': {'type': 'string', 'format': 'binary', 'description': 'PDF or image (PNG, JPEG, GIF, WebP). Max 25 MB.'},
+        },
+        'required': ['document_type', 'title', 'file'],
+    }
+}
+
+_LEASE_DOC_JSON_SCHEMA = {
+    'application/json': {
+        'type': 'object',
+        'properties': {
+            'document_type': {
+                'type': 'string',
+                'enum': ['lease_agreement', 'addendum', 'notice', 'other'],
+            },
+            'title': {'type': 'string'},
+            'file_url': {
+                'type': 'string',
+                'format': 'uri',
+                'description': 'Legacy: URL of a pre-hosted document.',
+            },
+        },
+        'required': ['document_type', 'title', 'file_url'],
+    }
+}
+
+
 @extend_schema(methods=['GET'], summary="List documents for a lease")
 @extend_schema(
     methods=['POST'],
     summary="Upload a document for a lease",
+    request={
+        **_LEASE_DOC_MULTIPART_SCHEMA,
+        **_LEASE_DOC_JSON_SCHEMA,
+    },
     examples=[
-        OpenApiExample("Upload lease document", request_only=True, value={
-            "document_type": "lease_agreement",
-            "title": "Signed Lease Agreement 2026",
-            "file_url": "https://storage.example.com/leases/doc-001.pdf",
-        })
+        OpenApiExample(
+            "Multipart upload (preferred)",
+            request_only=True,
+            value={
+                "document_type": "lease_agreement",
+                "title": "Signed Lease Agreement 2026",
+                "file": "<binary>",
+            },
+        ),
+        OpenApiExample(
+            "Legacy JSON with file_url",
+            request_only=True,
+            value={
+                "document_type": "lease_agreement",
+                "title": "Signed Lease Agreement 2026",
+                "file_url": "https://storage.example.com/leases/doc-001.pdf",
+            },
+        ),
     ],
 )
 @api_view(['GET', 'POST'])
@@ -814,13 +869,13 @@ def lease_document_list_create(request, lease_id):
 
     if request.method == 'GET':
         docs = LeaseDocument.objects.filter(lease=lease).select_related('uploaded_by', 'signed_by')
-        serializer = LeaseDocumentSerializer(docs, many=True)
+        serializer = LeaseDocumentSerializer(docs, many=True, context={'request': request})
         return Response(serializer.data)
 
     elif request.method == 'POST':
         if not (is_admin(request.user) or is_owner or is_assigned_agent):
             return Response({'detail': 'Only the landlord or assigned agent can upload documents.'}, status=status.HTTP_403_FORBIDDEN)
-        serializer = LeaseDocumentSerializer(data=request.data)
+        serializer = LeaseDocumentSerializer(data=request.data, context={'request': request})
         if serializer.is_valid():
             serializer.save(lease=lease, uploaded_by=request.user)
             return Response(serializer.data, status=status.HTTP_201_CREATED)
@@ -828,8 +883,36 @@ def lease_document_list_create(request, lease_id):
 
 
 @extend_schema(methods=['GET'], summary="Get a lease document")
+@extend_schema(
+    methods=['PUT', 'PATCH'],
+    summary="Update a lease document (metadata and/or replace file)",
+    request={
+        'multipart/form-data': {
+            'type': 'object',
+            'properties': {
+                'document_type': {
+                    'type': 'string',
+                    'enum': ['lease_agreement', 'addendum', 'notice', 'other'],
+                },
+                'title': {'type': 'string'},
+                'file': {'type': 'string', 'format': 'binary'},
+            },
+        },
+        'application/json': {
+            'type': 'object',
+            'properties': {
+                'document_type': {
+                    'type': 'string',
+                    'enum': ['lease_agreement', 'addendum', 'notice', 'other'],
+                },
+                'title': {'type': 'string'},
+                'file_url': {'type': 'string', 'format': 'uri'},
+            },
+        },
+    },
+)
 @extend_schema(methods=['DELETE'], summary="Delete a lease document")
-@api_view(['GET', 'DELETE'])
+@api_view(['GET', 'PUT', 'PATCH', 'DELETE'])
 @permission_classes([IsAuthenticated])
 def lease_document_detail(request, lease_id, doc_id):
     try:
@@ -851,14 +934,75 @@ def lease_document_detail(request, lease_id, doc_id):
         return Response({'detail': 'Permission denied.'}, status=status.HTTP_403_FORBIDDEN)
 
     if request.method == 'GET':
-        serializer = LeaseDocumentSerializer(doc)
+        serializer = LeaseDocumentSerializer(doc, context={'request': request})
         return Response(serializer.data)
+
+    elif request.method in ('PUT', 'PATCH'):
+        if not (is_admin(request.user) or is_owner or is_assigned_agent):
+            return Response({'detail': 'Only the landlord or assigned agent can update documents.'}, status=status.HTTP_403_FORBIDDEN)
+        serializer = LeaseDocumentSerializer(
+            doc,
+            data=request.data,
+            partial=True,
+            context={'request': request},
+        )
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     elif request.method == 'DELETE':
         if not (is_admin(request.user) or is_owner or is_assigned_agent):
             return Response({'detail': 'Only the landlord or assigned agent can delete documents.'}, status=status.HTTP_403_FORBIDDEN)
         doc.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+@extend_schema(
+    methods=['GET'],
+    summary="Download uploaded lease document file (auth required)",
+    responses={
+        200: OpenApiResponse(description='Binary file (Content-Disposition: attachment)'),
+        404: OpenApiResponse(description='No server-stored file (legacy external URL only)'),
+    },
+)
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
+def lease_document_download(request, lease_id, doc_id):
+    try:
+        lease = Lease.objects.select_related('unit__property', 'tenant').get(pk=lease_id)
+    except Lease.DoesNotExist:
+        return Response({'detail': 'Lease not found.'}, status=status.HTTP_404_NOT_FOUND)
+
+    try:
+        doc = LeaseDocument.objects.select_related('uploaded_by').get(pk=doc_id, lease=lease)
+    except LeaseDocument.DoesNotExist:
+        return Response({'detail': 'Document not found.'}, status=status.HTTP_404_NOT_FOUND)
+
+    prop = lease.unit.property
+    is_owner = prop.owner == request.user
+    is_assigned_agent = is_agent_for(request.user, prop)
+    is_lease_tenant = lease.tenant == request.user
+
+    if not (is_admin(request.user) or is_owner or is_assigned_agent or is_lease_tenant):
+        return Response({'detail': 'Permission denied.'}, status=status.HTTP_403_FORBIDDEN)
+
+    if not doc.file:
+        return Response(
+            {
+                'detail': (
+                    'This document has no server-stored file. Open `file_url` from the document JSON '
+                    '(legacy external link).'
+                ),
+            },
+            status=status.HTTP_404_NOT_FOUND,
+        )
+
+    filename = os.path.basename(doc.file.name)
+    content_type, _ = mimetypes.guess_type(filename)
+    if not content_type:
+        content_type = 'application/octet-stream'
+    return FileResponse(doc.file.open('rb'), as_attachment=True, filename=filename, content_type=content_type)
 
 
 @extend_schema(
@@ -890,7 +1034,7 @@ def lease_document_sign(request, lease_id, doc_id):
     doc.signed_by = request.user
     doc.signed_at = timezone.now()
     doc.save()
-    return Response(LeaseDocumentSerializer(doc).data)
+    return Response(LeaseDocumentSerializer(doc, context={'request': request}).data)
 
 
 # ── Property Reviews ──────────────────────────────────────────────────────────

--- a/treeHouse/settings.py
+++ b/treeHouse/settings.py
@@ -218,6 +218,9 @@ STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 # Media files (User uploads)
 MEDIA_URL = 'media/'
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+# Lease documents and similar uploads (multipart); must exceed app-level max (25 MB) + overhead.
+DATA_UPLOAD_MAX_MEMORY_SIZE = 26 * 1024 * 1024
+FILE_UPLOAD_MAX_MEMORY_SIZE = 26 * 1024 * 1024
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.1/ref/settings/#default-auto-field


### PR DESCRIPTION
…wnload

Made-with: Cursor

## Summary by Sourcery

Add first-class server-side lease document file uploads with authenticated downloads and update support while maintaining compatibility with legacy external URLs.

New Features:
- Support multipart/form-data uploads for lease documents alongside legacy JSON file_url creation.
- Expose an authenticated download endpoint for server-stored lease document files and surface its URL via the API response.
- Allow updating lease document metadata and replacing uploaded files via PUT/PATCH.

Enhancements:
- Extend LeaseDocument model and serializer to store files on disk with scoped, non-guessable paths while keeping legacy file_url rows working.
- Validate lease document uploads for size and allowed types, returning 413 for oversized files and 400 for invalid formats.
- Tighten lease document permissions so only owners/agents can modify or delete documents, and tenants can download when allowed.
- Update API docs and internal docs to describe the new upload, download, and update flows for lease documents, including limits and error behavior.
- Adjust project settings to accommodate larger lease document uploads and refine setup docs formatting.

Documentation:
- Document multipart lease document uploads, authenticated downloads, and update semantics, including file size/type limits and legacy behavior in the integration guide.

Tests:
- Add tests for multipart uploads, download behavior for stored vs legacy URLs, file validation errors, and landlord document updates.

Chores:
- Describe the new lease document endpoints and permissions in the contributor guide and update maintenance request choice labels.