### PR TITLE
fix(property): support ?token= for lease document download in browser

### DIFF
--- a/docs/api-integration.md
+++ b/docs/api-integration.md
@@ -1990,7 +1990,9 @@ Do not send both `file` and `file_url` on create.
 
 `GET /api/property/leases/<lease_id>/documents/<doc_id>/download/`
 
-Returns the stored file with `Content-Disposition: attachment` and an appropriate `Content-Type`. Requires authentication; same access rules as document detail.
+Returns the stored file with `Content-Disposition: attachment` and an appropriate `Content-Type`. Same access rules as document detail.
+
+**Authentication:** Prefer `Authorization: Token <key>` (e.g. `fetch` or API clients). For **opening the URL in a browser** (new tab, `<a href>`, `window.open`), the client cannot send headers; append **`?token=<key>`** to the download URL instead. The API does **not** include the token in `file_url` JSON — the app must add the query parameter when building a navigable link. Tokens in URLs can appear in logs and history; use HTTPS and treat links like secrets.
 
 Returns `404` if the document only has a legacy external `file_url` (no server file) — clients should use the URL from the document JSON in that case.
 

--- a/monitoring/authentication.py
+++ b/monitoring/authentication.py
@@ -1,5 +1,35 @@
-from rest_framework.authentication import TokenAuthentication
+from rest_framework.authentication import BaseAuthentication, TokenAuthentication
 from rest_framework.exceptions import AuthenticationFailed, PermissionDenied
+
+
+class QueryParameterTokenAuthentication(BaseAuthentication):
+    """
+    Authenticates using ?token=<key> against the DRF authtoken Token model.
+
+    Browser navigations (e.g. opening a file URL in a new tab) do not send
+    Authorization headers; append the token as a query parameter for those cases.
+    Invalid tokens raise AuthenticationFailed; missing token returns None so other
+    authenticators (e.g. header-based Token auth) can run.
+    """
+
+    def authenticate(self, request):
+        key = request.query_params.get('token')
+        if not key:
+            return None
+        from rest_framework.authtoken.models import Token
+
+        try:
+            token = Token.objects.select_related('user').get(key=key)
+        except Token.DoesNotExist:
+            raise AuthenticationFailed('Invalid token.')
+        if not token.user.is_active:
+            raise AuthenticationFailed('User inactive or deleted.')
+        return (token.user, token)
+
+    def authenticate_header(self, request):
+        # Must match TokenAuthentication so APIView does not coerce 401 → 403 when
+        # authenticate_header() would otherwise be None (DRF uses authenticators[0]).
+        return 'Token'
 
 
 class ImpersonatingTokenAuthentication(TokenAuthentication):

--- a/property/tests.py
+++ b/property/tests.py
@@ -655,6 +655,37 @@ class LeaseDocumentTests(APITestCase):
         self.assertEqual(dr.status_code, status.HTTP_200_OK)
         self.assertEqual(dr['Content-Type'], 'application/pdf')
 
+    def test_download_accepts_token_query_param_without_authorization_header(self):
+        """Browser navigation to file_url does not send Authorization; ?token= is supported."""
+        self.auth(self.landlord_token)
+        pdf = SimpleUploadedFile('q.pdf', b'%PDF-1.4 z', content_type='application/pdf')
+        r = self.client.post(
+            self._doc_list_url(),
+            {'document_type': 'other', 'title': 'Q', 'file': pdf},
+            format='multipart',
+        )
+        download_url = reverse('lease-document-download', args=[self.lease.id, r.data['id']])
+        self.client.credentials()
+        self.client.force_authenticate(user=None)
+        dr = self.client.get(download_url, {'token': self.landlord_token.key})
+        self.assertEqual(dr.status_code, status.HTTP_200_OK)
+
+    def test_download_rejects_invalid_query_token(self):
+        self.auth(self.landlord_token)
+        pdf = SimpleUploadedFile('q.pdf', b'%PDF-1.4 z', content_type='application/pdf')
+        r = self.client.post(
+            self._doc_list_url(),
+            {'document_type': 'other', 'title': 'Q', 'file': pdf},
+            format='multipart',
+        )
+        download_url = reverse('lease-document-download', args=[self.lease.id, r.data['id']])
+        self.client.credentials()
+        self.client.force_authenticate(user=None)
+        # Not a hex string — cannot match a real authtoken `key` (40-char hex).
+        fake_token = 'z' * 40
+        dr = self.client.get(download_url, {'token': fake_token})
+        self.assertEqual(dr.status_code, status.HTTP_401_UNAUTHORIZED)
+
     def test_download_legacy_external_only_returns_404(self):
         doc = self._make_doc()
         download_url = reverse('lease-document-download', args=[self.lease.id, doc.id])

--- a/property/views.py
+++ b/property/views.py
@@ -9,7 +9,7 @@ from django.core.exceptions import ValidationError as DjangoValidationError
 
 from django.http import FileResponse
 from django.utils import timezone
-from rest_framework.decorators import api_view, permission_classes
+from rest_framework.decorators import api_view, authentication_classes, permission_classes
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.response import Response
 from rest_framework import status
@@ -43,6 +43,7 @@ from .tenant_invite import (
     send_existing_tenant_lease_email,
 )
 from authentication.models import Role, TenantProfile, CustomUser
+from monitoring.authentication import ImpersonatingTokenAuthentication, QueryParameterTokenAuthentication
 from rest_framework.authtoken.models import Token
 
 
@@ -961,12 +962,17 @@ def lease_document_detail(request, lease_id, doc_id):
 @extend_schema(
     methods=['GET'],
     summary="Download uploaded lease document file (auth required)",
+    description=(
+        "Uses the same token as other API calls: `Authorization: Token <key>`, or for browser "
+        "navigation (new tab / `<a href>`) append `?token=<key>` because headers are not sent."
+    ),
     responses={
         200: OpenApiResponse(description='Binary file (Content-Disposition: attachment)'),
         404: OpenApiResponse(description='No server-stored file (legacy external URL only)'),
     },
 )
 @api_view(['GET'])
+@authentication_classes([QueryParameterTokenAuthentication, ImpersonatingTokenAuthentication])
 @permission_classes([IsAuthenticated])
 def lease_document_download(request, lease_id, doc_id):
     try:


### PR DESCRIPTION
Add QueryParameterTokenAuthentication with WWW-Authenticate header so missing/invalid auth returns 401; wire download view; document and test.

Made-with: Cursor

## Summary by Sourcery

Support token-based authentication via query parameters for lease document downloads and update related documentation and tests.

New Features:
- Allow lease document downloads to be authenticated using a `token` query parameter for browser-initiated requests that cannot send headers.

Bug Fixes:
- Ensure invalid or missing download tokens correctly return 401 Unauthorized instead of being treated as generic permission errors.

Enhancements:
- Introduce a reusable QueryParameterTokenAuthentication class aligned with existing token authentication behavior.
- Clarify API schema description for lease document downloads to document header and query-parameter token authentication options.

Documentation:
- Expand lease document download API documentation to describe how to use `Authorization` headers versus `?token=` for browser navigation and security considerations.

Tests:
- Add tests verifying successful lease document download with a `token` query parameter and 401 responses for invalid query tokens.