### PR TITLE
Register all models in Django admin for staff exploration

### DIFF
--- a/authentication/admin.py
+++ b/authentication/admin.py
@@ -1,6 +1,31 @@
 from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 
-from .models import CustomUser
+from .models import (
+    AgentProfile,
+    ArtisanProfile,
+    CustomUser,
+    LandlordProfile,
+    MovingCompanyProfile,
+    NotificationPreference,
+    Role,
+    TenantProfile,
+)
 
 
-admin.site.register(CustomUser)
+@admin.register(CustomUser)
+class CustomUserAdmin(BaseUserAdmin):
+    list_display = (*BaseUserAdmin.list_display, 'role', 'phone')
+    list_filter = (*BaseUserAdmin.list_filter, 'role')
+    search_fields = (*BaseUserAdmin.search_fields, 'phone')
+    fieldsets = BaseUserAdmin.fieldsets + (('Profile', {'fields': ('phone', 'role')}),)
+    add_fieldsets = BaseUserAdmin.add_fieldsets + ((None, {'fields': ('phone', 'role')}),)
+
+
+admin.site.register(Role)
+admin.site.register(TenantProfile)
+admin.site.register(LandlordProfile)
+admin.site.register(AgentProfile)
+admin.site.register(NotificationPreference)
+admin.site.register(ArtisanProfile)
+admin.site.register(MovingCompanyProfile)

--- a/billing/admin.py
+++ b/billing/admin.py
@@ -1,0 +1,23 @@
+from django.contrib import admin
+
+from .models import (
+    AdditionalIncome,
+    BillingConfig,
+    ChargeType,
+    Expense,
+    Invoice,
+    Payment,
+    PropertyBillingNotificationSettings,
+    Receipt,
+    ReminderLog,
+)
+
+admin.site.register(BillingConfig)
+admin.site.register(PropertyBillingNotificationSettings)
+admin.site.register(Invoice)
+admin.site.register(Payment)
+admin.site.register(Receipt)
+admin.site.register(ReminderLog)
+admin.site.register(ChargeType)
+admin.site.register(AdditionalIncome)
+admin.site.register(Expense)

--- a/dashboard/admin.py
+++ b/dashboard/admin.py
@@ -1,0 +1,5 @@
+from django.contrib import admin
+
+from .models import RoleChangeLog
+
+admin.site.register(RoleChangeLog)

--- a/disputes/admin.py
+++ b/disputes/admin.py
@@ -1,0 +1,6 @@
+from django.contrib import admin
+
+from .models import Dispute, DisputeMessage
+
+admin.site.register(Dispute)
+admin.site.register(DisputeMessage)

--- a/maintenance/admin.py
+++ b/maintenance/admin.py
@@ -1,0 +1,8 @@
+from django.contrib import admin
+
+from .models import MaintenanceBid, MaintenanceImage, MaintenanceNote, MaintenanceRequest
+
+admin.site.register(MaintenanceRequest)
+admin.site.register(MaintenanceBid)
+admin.site.register(MaintenanceNote)
+admin.site.register(MaintenanceImage)

--- a/messaging/admin.py
+++ b/messaging/admin.py
@@ -1,0 +1,7 @@
+from django.contrib import admin
+
+from .models import Conversation, ConversationParticipant, Message
+
+admin.site.register(Conversation)
+admin.site.register(ConversationParticipant)
+admin.site.register(Message)

--- a/monitoring/admin.py
+++ b/monitoring/admin.py
@@ -1,0 +1,8 @@
+from django.contrib import admin
+
+from .models import AlertInstance, AlertRule, ImpersonationLog, SystemMetric
+
+admin.site.register(SystemMetric)
+admin.site.register(AlertRule)
+admin.site.register(AlertInstance)
+admin.site.register(ImpersonationLog)

--- a/moving/admin.py
+++ b/moving/admin.py
@@ -1,0 +1,6 @@
+from django.contrib import admin
+
+from .models import MovingBooking, MovingCompanyReview
+
+admin.site.register(MovingBooking)
+admin.site.register(MovingCompanyReview)

--- a/neighborhood/admin.py
+++ b/neighborhood/admin.py
@@ -1,0 +1,5 @@
+from django.contrib import admin
+
+from .models import NeighborhoodInsight
+
+admin.site.register(NeighborhoodInsight)

--- a/notifications/admin.py
+++ b/notifications/admin.py
@@ -1,0 +1,5 @@
+from django.contrib import admin
+
+from .models import Notification
+
+admin.site.register(Notification)

--- a/property/admin.py
+++ b/property/admin.py
@@ -1,3 +1,27 @@
 from django.contrib import admin
 
-# Register your models here.
+from .models import (
+    Lease,
+    LeaseDocument,
+    Property,
+    PropertyAgent,
+    PropertyImage,
+    PropertyReview,
+    SavedSearch,
+    TenantApplication,
+    TenantInvitation,
+    TenantReview,
+    Unit,
+)
+
+admin.site.register(Property)
+admin.site.register(Unit)
+admin.site.register(Lease)
+admin.site.register(PropertyImage)
+admin.site.register(PropertyAgent)
+admin.site.register(TenantApplication)
+admin.site.register(LeaseDocument)
+admin.site.register(PropertyReview)
+admin.site.register(TenantReview)
+admin.site.register(SavedSearch)
+admin.site.register(TenantInvitation)


### PR DESCRIPTION
Made-with: Cursor

## Summary by Sourcery

Register authentication-related models in Django admin and enhance the CustomUser admin interface for easier staff management and exploration.

New Features:
- Expose role and profile-related models (tenant, landlord, agent, artisan, moving company, notification preferences) in the Django admin.
- Extend the CustomUser admin to display, filter, and search by role and phone fields, and include them in the user edit and creation forms.