### PR TITLE
Patch Django BaseContext.copy for Python 3.14 + Django 4.2

### DIFF
--- a/authentication/apps.py
+++ b/authentication/apps.py
@@ -4,3 +4,8 @@ from django.apps import AppConfig
 class AuthenticationConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'authentication'
+
+    def ready(self):
+        from treeHouse.django_compat import patch_base_context_copy_for_python_314
+
+        patch_base_context_copy_for_python_314()

--- a/treeHouse/django_compat.py
+++ b/treeHouse/django_compat.py
@@ -1,0 +1,27 @@
+"""Compatibility shims for running supported Django LTS on newer Python releases."""
+
+from __future__ import annotations
+
+import sys
+
+
+def patch_base_context_copy_for_python_314() -> None:
+    """
+    Django 4.2's BaseContext.__copy__ uses ``copy(super())``, which on Python
+    3.14+ can yield a copied *super* proxy (no ``dicts``), breaking admin and
+    any view that copies template contexts. Upstream fixed this in Django 5.2+.
+    """
+    if sys.version_info < (3, 14):
+        return
+
+    from copy import copy as copy_fn
+    from django.template.context import BaseContext
+
+    def __copy__(self):
+        duplicate = BaseContext()
+        duplicate.__class__ = self.__class__
+        duplicate.__dict__ = copy_fn(self.__dict__)
+        duplicate.dicts = self.dicts[:]
+        return duplicate
+
+    BaseContext.__copy__ = __copy__


### PR DESCRIPTION
Made-with: Cursor

## Summary by Sourcery

Add a Django compatibility shim that patches BaseContext.__copy__ on Python 3.14+ and ensure it is applied at authentication app startup.

Enhancements:
- Introduce a django_compat module that overrides BaseContext.__copy__ on Python 3.14+ to match the fixed behavior in newer Django versions.
- Hook the compatibility patch into the Authentication app configuration so it runs during app initialization.